### PR TITLE
Fix vector clock robustness, serialization, and stats reset

### DIFF
--- a/src/Distributed/VectorClock.cs
+++ b/src/Distributed/VectorClock.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace Clockworks.Distributed;
 
 /// <summary>
@@ -358,7 +360,10 @@ public readonly struct VectorClock : IEquatable<VectorClock>
         var parts = new string[_nodeIds.Length];
         for (var i = 0; i < _nodeIds.Length; i++)
         {
-            parts[i] = $"{_nodeIds[i]}:{_counters[i]}";
+            parts[i] = string.Concat(
+                _nodeIds[i].ToString(CultureInfo.InvariantCulture),
+                ":",
+                _counters[i].ToString(CultureInfo.InvariantCulture));
         }
         return string.Join(',', parts);
     }
@@ -382,8 +387,8 @@ public readonly struct VectorClock : IEquatable<VectorClock>
             if (parts.Length != 2)
                 throw new FormatException($"Invalid vector clock entry: {entry}");
 
-            var nodeId = ushort.Parse(parts[0]);
-            var counter = ulong.Parse(parts[1]);
+            var nodeId = ushort.Parse(parts[0], NumberStyles.None, CultureInfo.InvariantCulture);
+            var counter = ulong.Parse(parts[1], NumberStyles.None, CultureInfo.InvariantCulture);
             pairs.Add((nodeId, counter));
         }
 

--- a/src/Distributed/VectorClockCoordinator.cs
+++ b/src/Distributed/VectorClockCoordinator.cs
@@ -155,10 +155,10 @@ public sealed class VectorClockStatistics
     /// </summary>
     public void Reset()
     {
-        _localEventCount = 0;
-        _sendCount = 0;
-        _receiveCount = 0;
-        _clockMerges = 0;
+        Interlocked.Exchange(ref _localEventCount, 0);
+        Interlocked.Exchange(ref _sendCount, 0);
+        Interlocked.Exchange(ref _receiveCount, 0);
+        Interlocked.Exchange(ref _clockMerges, 0);
     }
 
     /// <summary>


### PR DESCRIPTION
 Summary:

- Canonicalize duplicate/unsorted node IDs when parsing/reading vector clocks (max counter wins)
- Use invariant culture for string formatting/parsing, with tests for non‑ASCII digit cultures
- Widen binary count header to 4 bytes (uint) and update binary tests
- Make VectorClockStatistics.Reset atomic and add concurrent reset test