### PR TITLE
Property tests effectiveness assessment

### DIFF
--- a/tests-property/SimulatedTimeProviderProperties.fs
+++ b/tests-property/SimulatedTimeProviderProperties.fs
@@ -16,9 +16,10 @@ let ``GetUtcNow and GetTimestamp are initially consistent`` (initialMs: int64) =
     let utcNow1 = timeProvider.GetUtcNow()
     let timestamp1 = timeProvider.GetTimestamp()
     let utcNow2 = timeProvider.GetUtcNow()
+    let timestamp2 = timeProvider.GetTimestamp()
     
     // Time should not advance without explicit calls
-    utcNow1 = utcNow2
+    utcNow1 = utcNow2 && timestamp1 = timestamp2
 
 /// Property: Advancing time should be atomic and deterministic
 [<Property>]
@@ -90,13 +91,13 @@ let ``Timer callbacks fire in order`` (delays: uint16 list) =
         let expectedOrder = 
             safeDelays
             |> List.mapi (fun idx delay -> (idx, delay))
-            |> List.sortBy snd
+            |> List.sortBy (fun (idx, delay) -> delay, idx)
             |> List.map fst
         
         let actualOrder = firedOrder |> List.rev
         
         // All timers should have fired
-        actualOrder.Length = safeDelays.Length
+        actualOrder.Length = safeDelays.Length && actualOrder = expectedOrder
 
 /// Property: Advance should set time relative to current time
 [<Property>]

--- a/tests-property/Tests.fs
+++ b/tests-property/Tests.fs
@@ -1,8 +1,0 @@
-﻿module Tests
-
-open System
-open Xunit
-
-[<Fact>]
-let ``My test`` () =
-    Assert.True(true)


### PR DESCRIPTION
Refactor property tests for `HlcTimestamp`, `SimulatedTimeProvider`, and `UuidV7Factory` to fix correctness issues, remove trivial checks, and improve test value.

Existing property tests contained several issues: incorrect byte ordering assumptions for GUID timestamps, incomplete assertions for timer ordering, invalid input domain for packed timestamps, and a critical unsafe/always-passing test for `SpinWait` counter overflow. This PR addresses these to ensure the tests are accurate, meaningful, and provide proper validation of the library's invariants.

---
<a href="https://cursor.com/background-agent?bcId=bc-d1355b41-eff1-4b45-83fd-b4ea4e36da79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d1355b41-eff1-4b45-83fd-b4ea4e36da79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

