### PR TITLE
Update property test plan counts

### DIFF
--- a/tests-property/PROPERTY_TESTING_PLAN.md
+++ b/tests-property/PROPERTY_TESTING_PLAN.md
@@ -2,7 +2,7 @@
 
 ## Executive Summary
 
-This document outlines the planning, implementation, and identification of property-based testing opportunities for the Clockworks library. We have successfully created an F# property test project using FsCheck that tests the core features of Clockworks through 27 property tests.
+This document outlines the planning, implementation, and identification of property-based testing opportunities for the Clockworks library. We have successfully created an F# property test project using FsCheck that tests the core features of Clockworks through 25 property tests.
 
 ## Project Background
 
@@ -26,14 +26,13 @@ This document outlines the planning, implementation, and identification of prope
 **Properties Tested:**
 - Sequential monotonicity (100 tests)
 - Timestamp prefix consistency at same millisecond (50 tests)
-- Time advancement effects (50 tests)
-- Version 7 and RFC 4122 variant bits (100 tests)
-- Counter overflow handling (1 deterministic test)
+- Time advancement changes UUID ordering (50 tests)
+- Counter overflow spin-wait resumes after time advances (1 deterministic test)
 - UUID uniqueness (50 tests with 10-265 UUIDs each)
-- Timestamp extraction accuracy (50 tests)
+- UUIDs change with time (50 tests)
 - Concurrent generation uniqueness (20 tests)
 
-**Test Coverage:** 8 properties
+**Test Coverage:** 7 tests
 
 #### 2. **HlcTimestamp** ⭐⭐⭐
 **Why Property Testing?**
@@ -47,14 +46,13 @@ This document outlines the planning, implementation, and identification of prope
 - Comparison transitivity: a ≤ b ∧ b ≤ c → a ≤ c
 - Comparison reflexivity: a = a
 - Comparison antisymmetry: a ≤ b ∧ b ≤ a → a = b
-- Total ordering: any two timestamps are comparable
 - Wall time ordering: higher wallTime → later timestamp
 - Counter ordering: same wallTime, higher counter → later timestamp
 - NodeId ordering: same wallTime & counter, higher nodeId → later
 - Packed representation ordering preservation
 - Full 80-bit encoding round-trip (WriteTo ↔ ReadFrom)
 
-**Test Coverage:** 10 properties
+**Test Coverage:** 9 properties
 
 #### 3. **SimulatedTimeProvider** ⭐⭐
 **Why Property Testing?**
@@ -124,26 +122,26 @@ Clockworks/
 │       └── HlcCoordinator.cs
 ├── tests/                            # Existing C# xUnit tests (44 tests)
 │   └── Clockworks.Tests.csproj
-└── tests-property/                   # NEW: F# property tests (27 tests)
+└── tests-property/                   # NEW: F# property tests (25 tests)
     ├── Clockworks.PropertyTests.fsproj
-    ├── HlcTimestampProperties.fs     # 10 properties
-    ├── UuidV7FactoryProperties.fs    # 8 properties
+    ├── HlcTimestampProperties.fs     # 9 properties
+    ├── UuidV7FactoryProperties.fs    # 7 tests
     ├── SimulatedTimeProviderProperties.fs  # 9 properties
     └── README.md                     # Documentation
 ```
 
 ### Test Counts
 
-- **Total Property Tests**: 27
+- **Total Property Tests**: 25
 - **Total Example Tests** (existing): 44
-- **Combined Coverage**: 71 tests
+- **Combined Coverage**: 69 tests
 
 ### Property Test Distribution
 
 ```
-HlcTimestamp:           10 tests (37%)
-SimulatedTimeProvider:   9 tests (33%)
-UuidV7Factory:          8 tests (30%)
+HlcTimestamp:            9 tests (36%)
+SimulatedTimeProvider:   9 tests (36%)
+UuidV7Factory:           7 tests (28%)
 ```
 
 ## Property Testing Benefits for Clockworks
@@ -179,20 +177,7 @@ Property tests serve as executable specifications:
 
 ### Issues to Fix
 
-1. **HlcTimestamp Generator** ⚠️
-   - **Issue**: FsCheck can't auto-generate C# record struct
-   - **Fix**: Create custom `Arbitrary<HlcTimestamp>` generator
-   - **Impact**: 5 tests currently fail with "not handled automatically"
-
-2. **GetElapsedTime Precision** ⚠️
-   - **Issue**: Floating-point rounding causes occasional failures
-   - **Fix**: Allow small epsilon (< 1ms) in comparison
-   - **Impact**: 1 test fails intermittently
-
-3. **UUID Timestamp Extraction** ⚠️
-   - **Issue**: Byte order handling in timestamp extraction
-   - **Fix**: Verify big-endian extraction logic
-   - **Impact**: 1 test fails
+- None currently in the property test suite. All 25 tests pass locally.
 
 ### Future Property Tests
 
@@ -220,7 +205,7 @@ Property tests serve as executable specifications:
 ✅ **Project Setup Complete**
 - F# test project created and integrated
 - FsCheck.Xunit.v3 configured with xUnit v3
-- 27 properties discovered and running
+- 25 properties discovered and running
 - Build and test infrastructure working
 
 ✅ **Documentation Complete**
@@ -230,19 +215,18 @@ Property tests serve as executable specifications:
 - Future work identified
 
 ✅ **Core Features Covered**
-- UuidV7Factory: 8 properties covering monotonicity, RFC compliance, concurrency
-- HlcTimestamp: 10 properties covering causality, ordering, encoding
+- UuidV7Factory: 7 tests covering monotonicity, timestamp behavior, overflow handling, uniqueness, concurrency
+- HlcTimestamp: 9 properties covering ordering and encoding
 - SimulatedTimeProvider: 9 properties covering determinism, timers, advancement
 
-⚠️ **Minor Issues to Resolve** (3 failing tests)
-- Custom generator needed for HlcTimestamp
-- Precision adjustments for 2 numeric properties
+✅ **Property Suite Health**
+- 25/25 tests passing locally
 
 ## Recommendations
 
 ### For Immediate Use
-1. **Use passing tests now** - 24/27 tests provide immediate value
-2. **Fix 3 failing tests** - Straightforward fixes identified
+1. **Use passing tests now** - 25/25 tests provide immediate value
+2. **Keep failures actionable** - Treat property test failures as regressions
 3. **Integrate into CI** - Add property tests to build pipeline
 
 ### For Future Development
@@ -260,7 +244,7 @@ Property tests serve as executable specifications:
 
 We have successfully planned and implemented a comprehensive property-based testing framework for Clockworks using FsCheck in F#. The framework includes:
 
-- ✅ 27 property tests across 3 core components
+- ✅ 25 property tests across 3 core components
 - ✅ F# project integrated with existing C# codebase
 - ✅ xUnit v3 and FsCheck.Xunit.v3 integration
 - ✅ Comprehensive documentation and best practices


### PR DESCRIPTION
Reflect the current 25-test suite and align coverage details with the latest property tests.