### PR TITLE
Add HlcCoordinator Property Tests

### DIFF
--- a/Clockworks.sln
+++ b/Clockworks.sln
@@ -17,7 +17,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Clockworks.Demo", "demo\Clo
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Clockworks.IntegrationDemo", "demo\Clockworks.IntegrationDemo\Clockworks.IntegrationDemo.csproj", "{52933331-D795-3531-B002-E418C8C4A7EE}"
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Clockworks.PropertyTests", "tests-property\Clockworks.PropertyTests.fsproj", "{6C4D2BF7-4C26-4841-A4A7-D8EFE63894E3}"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Clockworks.PropertyTests", "property-tests\Clockworks.PropertyTests.fsproj", "{6C4D2BF7-4C26-4841-A4A7-D8EFE63894E3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/property-tests/Clockworks.PropertyTests.fsproj
+++ b/property-tests/Clockworks.PropertyTests.fsproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <Compile Include="HlcTimestampProperties.fs" />
+    <Compile Include="HlcCoordinatorProperties.fs" />
     <Compile Include="UuidV7FactoryProperties.fs" />
     <Compile Include="SimulatedTimeProviderProperties.fs" />
     <Compile Include="VectorClockProperties.fs" />

--- a/property-tests/HlcCoordinatorProperties.fs
+++ b/property-tests/HlcCoordinatorProperties.fs
@@ -1,0 +1,100 @@
+module Clockworks.PropertyTests.HlcCoordinatorProperties
+
+open System
+open FsCheck.Xunit
+open Clockworks
+open Clockworks.Distributed
+
+/// Property: Sequential sends should always produce increasing timestamps.
+[<Property(MaxTest = 100)>]
+let ``BeforeSend timestamps are strictly increasing`` (advances: uint16 list) =
+    let safeAdvances =
+        advances
+        |> List.map (fun ms -> int64 (ms % 5us))
+        |> List.truncate 20
+
+    let steps = if List.isEmpty safeAdvances then [0L] else safeAdvances
+    let timeProvider = new SimulatedTimeProvider()
+    use factory = new HlcGuidFactory(timeProvider, nodeId = 1us)
+    let coordinator = new HlcCoordinator(factory)
+
+    let mutable timestamps = [ coordinator.BeforeSend() ]
+    for advanceMs in steps do
+        if advanceMs > 0L then
+            timeProvider.Advance(TimeSpan.FromMilliseconds(float advanceMs))
+        timestamps <- coordinator.BeforeSend() :: timestamps
+
+    timestamps
+    |> List.rev
+    |> List.pairwise
+    |> List.forall (fun (prev, curr) -> prev < curr)
+
+/// Property: Receiving any remote timestamp always advances the local timestamp.
+[<Property>]
+let ``BeforeReceive advances the local timestamp`` (delta: int) =
+    let startMs = 1_700_000_000_000L
+    let timeProvider = SimulatedTimeProvider.FromUnixMs(startMs)
+    use factory = new HlcGuidFactory(timeProvider, nodeId = 1us)
+    let coordinator = new HlcCoordinator(factory)
+
+    let before = coordinator.CurrentTimestamp
+    let deltaMs = (abs (int64 delta) % 2000L) - 1000L
+    let remoteMs = before.WallTimeMs + deltaMs
+
+    coordinator.BeforeReceive(HlcTimestamp(remoteMs))
+
+    let after = coordinator.CurrentTimestamp
+    after > before
+
+/// Property: When the remote wall time is ahead, we adopt it and start counter at 1.
+[<Property>]
+let ``BeforeReceive adopts remote wall time when remote is ahead`` (deltaMs: uint16) =
+    let startMs = 1_700_000_000_000L
+    let timeProvider = SimulatedTimeProvider.FromUnixMs(startMs)
+    use factory = new HlcGuidFactory(timeProvider, nodeId = 1us)
+    let coordinator = new HlcCoordinator(factory)
+
+    let advanceMs = int64 (deltaMs % 1000us) + 1L
+    let remote = HlcTimestamp(coordinator.CurrentTimestamp.WallTimeMs + advanceMs)
+
+    coordinator.BeforeReceive(remote)
+
+    let after = coordinator.CurrentTimestamp
+    after.WallTimeMs = remote.WallTimeMs && after.Counter = 1us
+
+/// Property: Receive followed by send yields a timestamp after the remote.
+[<Property>]
+let ``Receive then send yields timestamp after remote`` (deltaMs: uint16) =
+    let startMs = 1_700_000_000_000L
+    let timeProvider = SimulatedTimeProvider.FromUnixMs(startMs)
+    use factory = new HlcGuidFactory(timeProvider, nodeId = 1us)
+    let coordinator = new HlcCoordinator(factory)
+
+    let advanceMs = int64 (deltaMs % 1000us) + 1L
+    let remote = HlcTimestamp(coordinator.CurrentTimestamp.WallTimeMs + advanceMs, counter = 0us, nodeId = 2us)
+
+    coordinator.BeforeReceive(remote)
+    let next = coordinator.BeforeSend()
+
+    next > remote
+
+/// Property: If physical time jumps ahead, the counter resets to zero on send.
+[<Property>]
+let ``BeforeSend resets counter when physical time jumps ahead`` (jumpMs: uint16) =
+    let jump = int64 (jumpMs % 10_000us) + 1L
+    let timeProvider = new SimulatedTimeProvider()
+    use factory = new HlcGuidFactory(timeProvider, nodeId = 1us)
+    let coordinator = new HlcCoordinator(factory)
+
+    let _ = coordinator.BeforeSend()
+    let _ = coordinator.BeforeSend()
+    let before = coordinator.CurrentTimestamp
+
+    let newPhysical = DateTimeOffset.FromUnixTimeMilliseconds(before.WallTimeMs + jump)
+    timeProvider.SetUtcNow(newPhysical)
+
+    let after = coordinator.BeforeSend()
+
+    after.WallTimeMs = newPhysical.ToUnixTimeMilliseconds()
+    && after.Counter = 0us
+    && after > before

--- a/property-tests/PROPERTY_TESTING_PLAN.md
+++ b/property-tests/PROPERTY_TESTING_PLAN.md
@@ -2,7 +2,7 @@
 
 ## Executive Summary
 
-This document outlines the planning, implementation, and identification of property-based testing opportunities for the Clockworks library. We have successfully created an F# property test project using FsCheck that tests the core features of Clockworks through 34 property tests.
+This document outlines the planning, implementation, and identification of property-based testing opportunities for the Clockworks library. We have successfully created an F# property test project using FsCheck that tests the core features of Clockworks through 39 property tests.
 
 ## Project Background
 
@@ -102,19 +102,22 @@ This document outlines the planning, implementation, and identification of prope
 
 **Test Coverage:** 2 properties
 
-### Medium Priority Features (Not Yet Implemented)
-
 #### 6. **HlcCoordinator** ⭐
 **Why Property Testing?**
-- Message send/receive creates causality chains that must be verified
-- Clock synchronization has mathematical properties
-- Counter resets on wall time advance need testing
+- Message send/receive is the core causality mechanism
+- Local monotonicity must hold across mixed send/receive sequences
+- Counter behavior depends on physical time and remote timestamps
 
-**Proposed Properties:**
-- Send timestamp < receive timestamp (causality)
-- Multiple sends create strict total order
-- Clock drift bounds after synchronization
-- Counter reset on wall time advance
+**Properties Tested:**
+- Sequential send timestamps are strictly increasing
+- Receiving any remote timestamp advances the local timestamp
+- Remote-ahead wall time is adopted with counter = 1
+- Receive then send yields a timestamp after the remote
+- Counter resets to 0 when physical time jumps ahead
+
+**Test Coverage:** 5 properties
+
+### Medium Priority Features (Not Yet Implemented)
 
 ## Implementation Details
 
@@ -140,9 +143,10 @@ Clockworks/
 │       └── HlcCoordinator.cs
 ├── tests/                            # Existing C# xUnit tests (44 tests)
 │   └── Clockworks.Tests.csproj
-└── tests-property/                   # NEW: F# property tests (34 tests)
+└── tests-property/                   # NEW: F# property tests (39 tests)
     ├── Clockworks.PropertyTests.fsproj
     ├── HlcTimestampProperties.fs     # 9 properties
+    ├── HlcCoordinatorProperties.fs   # 5 properties
     ├── UuidV7FactoryProperties.fs    # 7 tests
     ├── SimulatedTimeProviderProperties.fs  # 9 properties
     ├── VectorClockProperties.fs      # 7 properties
@@ -153,18 +157,19 @@ Clockworks/
 
 ### Test Counts
 
-- **Total Property Tests**: 34
+- **Total Property Tests**: 39
 - **Total Example Tests** (existing): 44
-- **Combined Coverage**: 78 tests
+- **Combined Coverage**: 83 tests
 
 ### Property Test Distribution
 
 ```
-HlcTimestamp:            9 tests (26%)
-SimulatedTimeProvider:   9 tests (26%)
-UuidV7Factory:           7 tests (21%)
-VectorClock:             7 tests (21%)
-Timeouts:                2 tests (6%)
+HlcTimestamp:            9 tests (23%)
+SimulatedTimeProvider:   9 tests (23%)
+UuidV7Factory:           7 tests (18%)
+VectorClock:             7 tests (18%)
+HlcCoordinator:          5 tests (13%)
+Timeouts:                2 tests (5%)
 ```
 
 ## Property Testing Benefits for Clockworks
@@ -200,25 +205,20 @@ Property tests serve as executable specifications:
 
 ### Issues to Fix
 
-- None currently in the property test suite. All 34 tests pass locally.
+- None currently in the property test suite. All 39 tests pass locally.
 
 ### Future Property Tests
 
-1. **HlcCoordinator** (4-6 properties)
-   - Message causality chains
-   - Clock synchronization bounds
-   - Counter management
-
-2. **VectorClockCoordinator** (3-4 properties)
+1. **VectorClockCoordinator** (3-4 properties)
    - Merge and increment behavior on send/receive
    - Causal ordering preservation
    - Concurrency detection with concurrent updates
 
-3. **Statistics/Instrumentation** (2-3 properties)
+2. **Statistics/Instrumentation** (2-3 properties)
    - Counter monotonicity
    - Metric accuracy
 
-4. **Performance Properties** (2-3 properties)
+3. **Performance Properties** (2-3 properties)
    - UUID generation completes within time bounds
    - Lock-free operations don't deadlock
    - Memory usage stays bounded
@@ -228,7 +228,7 @@ Property tests serve as executable specifications:
 ✅ **Project Setup Complete**
 - F# test project created and integrated
 - FsCheck.Xunit.v3 configured with xUnit v3
-- 34 properties discovered and running
+- 39 properties discovered and running
 - Build and test infrastructure working
 
 ✅ **Documentation Complete**
@@ -240,23 +240,24 @@ Property tests serve as executable specifications:
 ✅ **Core Features Covered**
 - UuidV7Factory: 7 tests covering monotonicity, timestamp behavior, overflow handling, uniqueness, concurrency
 - HlcTimestamp: 9 properties covering ordering and encoding
+- HlcCoordinator: 5 properties covering message causality and counter behavior
 - SimulatedTimeProvider: 9 properties covering determinism, timers, advancement
 - VectorClock: 7 properties covering merge algebra and serialization
 - Timeouts: 2 properties covering cancellation timing
 
 ✅ **Property Suite Health**
-- 34/34 tests passing locally
+- 39/39 tests passing locally
 
 ## Recommendations
 
 ### For Immediate Use
-1. **Use passing tests now** - 34/34 tests provide immediate value
+1. **Use passing tests now** - 39/39 tests provide immediate value
 2. **Keep failures actionable** - Treat property test failures as regressions
 3. **Integrate into CI** - Add property tests to build pipeline
 
 ### For Future Development
-1. **Add HlcCoordinator properties** - Critical for distributed scenarios
-2. **Add Timeouts properties** - Important for production use
+1. **Add VectorClockCoordinator properties** - Message flow invariants
+2. **Add statistics/instrumentation properties** - Validate counters/metrics
 3. **Consider stateful property testing** - For complex concurrent scenarios
 4. **Performance properties** - Verify lock-free algorithms scale
 
@@ -269,7 +270,7 @@ Property tests serve as executable specifications:
 
 We have successfully planned and implemented a comprehensive property-based testing framework for Clockworks using FsCheck in F#. The framework includes:
 
-- ✅ 34 property tests across 5 core components
+- ✅ 39 property tests across 6 core components
 - ✅ F# project integrated with existing C# codebase
 - ✅ xUnit v3 and FsCheck.Xunit.v3 integration
 - ✅ Comprehensive documentation and best practices
@@ -278,6 +279,7 @@ We have successfully planned and implemented a comprehensive property-based test
 The property tests provide rigorous verification of:
 - Monotonicity invariants (UuidV7Factory)
 - Causality preservation (HlcTimestamp)
+- Message causality coordination (HlcCoordinator)
 - Deterministic behavior (SimulatedTimeProvider)
 - Merge algebra and serialization (VectorClock)
 - Cancellation timing (Timeouts)

--- a/property-tests/README.md
+++ b/property-tests/README.md
@@ -17,6 +17,7 @@ Property-based testing complements traditional example-based unit tests by:
 tests-property/
 ├── Clockworks.PropertyTests.fsproj    # F# test project with FsCheck.Xunit.v3
 ├── HlcTimestampProperties.fs          # Properties for Hybrid Logical Clock timestamps
+├── HlcCoordinatorProperties.fs        # Properties for HLC message coordination
 ├── UuidV7FactoryProperties.fs         # Properties for UUIDv7 generation
 ├── SimulatedTimeProviderProperties.fs # Properties for deterministic time simulation
 ├── VectorClockProperties.fs           # Properties for Vector Clock ordering/merging
@@ -70,7 +71,23 @@ Tests for the Hybrid Logical Clock timestamp implementation, verifying causality
 - Multiple encoding formats (64-bit packed, 80-bit full) preserve ordering
 - Causality is maintained through the (wallTime, counter, nodeId) tuple
 
-### 2. UuidV7Factory Properties (`UuidV7FactoryProperties.fs`)
+### 2. HlcCoordinator Properties (`HlcCoordinatorProperties.fs`)
+
+Tests for HLC message coordination, ensuring causality and counter behavior.
+
+**Properties Tested:**
+- ✅ **Send monotonicity**: Sequential sends produce increasing timestamps
+- ✅ **Receive advances local**: Any receive advances the local timestamp
+- ✅ **Remote adoption**: Remote-ahead wall time is adopted with counter = 1
+- ✅ **Causal chain**: Receive then send yields a later timestamp than the remote
+- ✅ **Counter reset**: Physical time jumps reset the counter to zero on send
+
+**Invariants:**
+- Local timestamps always move forward on send/receive
+- Remote-ahead timestamps are adopted deterministically
+- Physical time bounds reset logical counters
+
+### 3. UuidV7Factory Properties (`UuidV7FactoryProperties.fs`)
 
 Tests for RFC 9562 UUIDv7 generation with monotonicity guarantees and time-based ordering.
 
@@ -88,7 +105,7 @@ Tests for RFC 9562 UUIDv7 generation with monotonicity guarantees and time-based
 - Sub-millisecond ordering via 12-bit counter
 - Lock-free generation is thread-safe
 
-### 3. SimulatedTimeProvider Properties (`SimulatedTimeProviderProperties.fs`)
+### 4. SimulatedTimeProvider Properties (`SimulatedTimeProviderProperties.fs`)
 
 Tests for deterministic time simulation ensuring reproducible test behavior.
 
@@ -108,7 +125,7 @@ Tests for deterministic time simulation ensuring reproducible test behavior.
 - Timers fire in predictable order based on scheduled times
 - No hidden time advancement
 
-### 4. VectorClock Properties (`VectorClockProperties.fs`)
+### 5. VectorClock Properties (`VectorClockProperties.fs`)
 
 Tests for the Vector Clock implementation, verifying merge algebra and serialization round-trips.
 
@@ -125,7 +142,7 @@ Tests for the Vector Clock implementation, verifying merge algebra and serializa
 - Merge yields the least upper bound of two clocks
 - Serialization formats preserve ordering and identity
 
-### 5. Timeouts Properties (`TimeoutsProperties.fs`)
+### 6. Timeouts Properties (`TimeoutsProperties.fs`)
 
 Tests for `Timeouts` cancellation semantics driven by a `TimeProvider`.
 
@@ -244,7 +261,6 @@ When testing concurrent code or using `TimeProvider.System`:
 
 ## Future Work
 
-- [ ] Add properties for `HlcCoordinator` message passing
 - [ ] Add properties for `VectorClockCoordinator` message flow
 - [ ] Performance properties (e.g., "UUID generation completes within X ms")
 - [ ] Stateful property testing for concurrent scenarios

--- a/src/Distributed/HlcTimestamp.cs
+++ b/src/Distributed/HlcTimestamp.cs
@@ -15,7 +15,7 @@
 /// The counter c provides ordering within the same logical millisecond,
 /// giving us O(1) comparison with bounded drift from physical time.
 /// </remarks>
-public readonly record struct HlcTimestamp : IComparable<HlcTimestamp>
+public readonly record struct HlcTimestamp : IComparable<HlcTimestamp>, IComparable
 {
     /// <summary>
     /// Logical wall time in milliseconds since Unix epoch.
@@ -124,6 +124,16 @@ public readonly record struct HlcTimestamp : IComparable<HlcTimestamp>
         if (cmp != 0) return cmp;
 
         return NodeId.CompareTo(other.NodeId);
+    }
+
+    /// <summary>
+    /// Compares this timestamp to another object.
+    /// </summary>
+    public int CompareTo(object? obj)
+    {
+        if (obj is null) return 1;
+        if (obj is HlcTimestamp other) return CompareTo(other);
+        throw new ArgumentException("Object must be of type HlcTimestamp", nameof(obj));
     }
 
     /// <summary>


### PR DESCRIPTION
- Added `HlcCoordinatorProperties.fs` with 5 properties (send monotonicity, receive advances local, remote adoption with counter=1, receive→send causal ordering, counter reset on physical jump).
- Wired the new file into the property test project and updated README + PROPERTY_TESTING_PLAN counts to 39 total properties.

---
<a href="https://cursor.com/background-agent?bcId=bc-66ac628d-6bfa-4884-96b0-f42c021714b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-66ac628d-6bfa-4884-96b0-f42c021714b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

