### PR TITLE
Docs: Align docs + Add changelog and versioning guidance

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,11 @@
+# Copilot Instructions
+
+## General Guidelines
+- First general instruction
+- Second general instruction
+
+## Versioning and Git Practices
+- Treat recent Clockworks changes as a minor version bump (semver).
+- Group commits for a clean git history.
+- Consider adopting git tags for versioning.
+- Move common build properties from `Clockworks.csproj` into `Directory.Build.props`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.2.0] - 2026-01-27
+
+### Changed
+- HLC receive semantics now witness the full remote `HlcTimestamp` `(wallTime, counter, nodeId)` (including nodeId tie-breaking) rather than only the remote wall time.
+- HLC coordinator receive statistics now treat "remote ahead" based on full timestamp ordering.
+
+### Added
+- Additional property tests for `HlcCoordinator` covering remote-ahead by counter, nodeId tie-breaking, remote-behind behavior, and mixed send/receive/time interleavings.
+- Unit test coverage for receiving a remote timestamp with higher counter at the same wall time.
+
+### Build
+- Centralized common build properties in `Directory.Build.props`.
+
+[Unreleased]: https://github.com/dexcompiler/Clockworks/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/dexcompiler/Clockworks/releases/tag/v1.2.0

--- a/property-tests/PROPERTY_TESTING_PLAN.md
+++ b/property-tests/PROPERTY_TESTING_PLAN.md
@@ -2,7 +2,8 @@
 
 ## Executive Summary
 
-This document outlines the planning, implementation, and identification of property-based testing opportunities for the Clockworks library. We have successfully created an F# property test project using FsCheck that tests the core features of Clockworks through 54 property tests.
+This document outlines the planning, implementation, and identification of property-based testing opportunities for the Clockworks library.
+The `property-tests/` project contains FsCheck-based property tests that exercise the core invariants of Clockworks.
 
 ## Project Background
 
@@ -111,11 +112,14 @@ This document outlines the planning, implementation, and identification of prope
 **Properties Tested:**
 - Sequential send timestamps are strictly increasing
 - Receiving any remote timestamp advances the local timestamp
-- Remote-ahead wall time is adopted with counter = 1
+- Remote-ahead wall time is adopted with counter advanced beyond remote
+- Remote-ahead within the same wall time (higher counter) is adopted and exceeded
+- NodeId tie-break cases are handled deterministically
 - Receive then send yields a timestamp after the remote
 - Counter resets to 0 when physical time jumps ahead
+- Mixed send/receive/physical-time sequences preserve invariants
 
-**Test Coverage:** 5 properties
+**Test Coverage:** 8 properties
 
 #### 7. **VectorClockCoordinator** ⭐
 **Why Property Testing?**
@@ -185,10 +189,10 @@ Clockworks/
 │       └── HlcCoordinator.cs
 ├── tests/                            # Existing C# xUnit tests (44 tests)
 │   └── Clockworks.Tests.csproj
-└── tests-property/                   # NEW: F# property tests (54 tests)
+└── property-tests/                   # F# property tests (FsCheck)
     ├── Clockworks.PropertyTests.fsproj
     ├── HlcTimestampProperties.fs     # 9 properties
-    ├── HlcCoordinatorProperties.fs   # 5 properties
+    ├── HlcCoordinatorProperties.fs   # 8 properties
     ├── InstrumentationStatisticsProperties.fs # 8 properties
     ├── PerformanceProperties.fs      # 3 properties
     ├── UuidV7FactoryProperties.fs    # 7 tests
@@ -202,23 +206,11 @@ Clockworks/
 
 ### Test Counts
 
-- **Total Property Tests**: 54
-- **Total Example Tests** (existing): 44
-- **Combined Coverage**: 98 tests
+Test counts change over time; use `dotnet test --list-tests` (or CI summaries) for the current totals.
 
 ### Property Test Distribution
 
-```
-HlcTimestamp:            9 tests (17%)
-SimulatedTimeProvider:   9 tests (17%)
-Instrumentation:         8 tests (15%)
-UuidV7Factory:           7 tests (13%)
-VectorClock:             7 tests (13%)
-HlcCoordinator:          5 tests (9%)
-VectorClockCoordinator:  4 tests (7%)
-Performance:             3 tests (6%)
-Timeouts:                2 tests (4%)
-```
+Distribution is tracked by module (see `property-tests/README.md`).
 
 ## Property Testing Benefits for Clockworks
 
@@ -253,7 +245,7 @@ Property tests serve as executable specifications:
 
 ### Issues to Fix
 
-- None currently in the property test suite. All 54 tests pass locally.
+- None currently in the property test suite.
 
 ### Future Property Tests
 

--- a/property-tests/README.md
+++ b/property-tests/README.md
@@ -2,6 +2,8 @@
 
 This directory contains property-based tests for the Clockworks library using [FsCheck](https://fscheck.github.io/FsCheck/), an F# implementation of QuickCheck for testing .NET code.
 
+For library usage docs, see the repo root `README.md`. For notable changes between releases, see `CHANGELOG.md`.
+
 ## Why Property Testing?
 
 Property-based testing complements traditional example-based unit tests by:
@@ -14,7 +16,7 @@ Property-based testing complements traditional example-based unit tests by:
 ## Project Structure
 
 ```
-tests-property/
+property-tests/
 ├── Clockworks.PropertyTests.fsproj    # F# test project with FsCheck.Xunit.v3
 ├── HlcTimestampProperties.fs          # Properties for Hybrid Logical Clock timestamps
 ├── HlcCoordinatorProperties.fs        # Properties for HLC message coordination
@@ -40,10 +42,10 @@ tests-property/
 
 ```bash
 # Run all property tests
-dotnet test tests-property/Clockworks.PropertyTests.fsproj
+dotnet test property-tests/Clockworks.PropertyTests.fsproj
 
 # Run with verbose output
-dotnet test tests-property/Clockworks.PropertyTests.fsproj -v detailed
+dotnet test property-tests/Clockworks.PropertyTests.fsproj -v detailed
 
 # Run specific test module
 dotnet test --filter "FullyQualifiedName~UuidV7FactoryProperties"
@@ -82,8 +84,15 @@ Tests for HLC message coordination, ensuring causality and counter behavior.
 - ✅ **Send monotonicity**: Sequential sends produce increasing timestamps
 - ✅ **Receive advances local**: Any receive advances the local timestamp
 - ✅ **Remote adoption**: Remote-ahead wall time is adopted with counter = 1
+- ✅ **Remote counter adoption**: Remote-ahead counter at same wall time is adopted and exceeded
+- ✅ **NodeId tie-break**: Remote ahead by nodeId (same wall time and counter) is adopted and exceeded
 - ✅ **Causal chain**: Receive then send yields a later timestamp than the remote
 - ✅ **Counter reset**: Physical time jumps reset the counter to zero on send
+- ✅ **Mixed interleavings**: Random send/receive/time sequences preserve invariants
+
+**Notes:**
+- Some properties use `HlcOptions.HighThroughput` to avoid drift exceptions in adversarial sequences
+  (e.g., when physical time is moved backwards) while still asserting monotonicity/causal ordering.
 
 **Invariants:**
 - Local timestamps always move forward on send/receive


### PR DESCRIPTION
Add CHANGELOG.md, document SemVer tagging and release conventions in README, and align property test docs with current folder layout and HLC coordinator coverage.