### PR TITLE
Optimize vector clock merge/compare/increment and binary serialization

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -3,6 +3,7 @@
 ## General Guidelines
 - First general instruction
 - Second general instruction
+- Prefer updating documentation comments for mathematical/complexity accuracy when refactoring; keep wire format and semantics unchanged unless explicitly requested.
 
 ## Versioning and Git Practices
 - Treat recent Clockworks changes as a minor version bump (semver).


### PR DESCRIPTION
This PR improves `VectorClock` performance by reducing allocations and avoiding repeated lookups in the most common operations (`Compare(VectorClock)`, `Merge(VectorClock)`, `Increment(ushort)`) and by using `BinaryPrimitives` for big-endian binary encoding/decoding. No behavior or wire-format changes are intended.
Changes:
- `Compare(VectorClock)`: replaced HashSet + repeated `Get( )` calls with a single linear merge-style walk over both sorted node-id arrays (allocation-free, O(n+m)).
- `Merge(VectorClock)`: removed `List<T>` usage and `ToArray( )` copies; now merges directly into pre-allocated arrays and trims to actual size.
- `Increment(ushort)`: when incrementing an existing node, share the immutable node-id array and copy only the counters array; small copy optimizations for insert case.
- `WriteTo(Span<byte>)` / `ReadFrom(ReadOnlySpan<byte>)`: use `System.Buffers.Binary.BinaryPrimitives` for big-endian reads/writes (same on-wire format).
- Docs: updated complexity claim in the `VectorClock` XML comment from O(n) to O(n+m).
- Repo guidance: updated .github/copilot-instructions.md to prefer mathematically precise complexity docs during refactors while preserving semantics/wire format.