### PR TITLE
Add high-value property tests for HLC and vector clocks

### DIFF
--- a/property-tests/HlcTimestampProperties.fs
+++ b/property-tests/HlcTimestampProperties.fs
@@ -6,6 +6,15 @@ open FsCheck.FSharp
 open FsCheck.Xunit
 open Clockworks.Distributed
 
+let private compareBytesLex (a: byte[]) (b: byte[]) =
+    let len = min a.Length b.Length
+    let mutable i = 0
+    let mutable cmp = 0
+    while i < len && cmp = 0 do
+        cmp <- compare a[i] b[i]
+        i <- i + 1
+    if cmp <> 0 then cmp else compare a.Length b.Length
+
 type HlcTimestampArb =
     static member HlcTimestamp() : FsCheck.Arbitrary<HlcTimestamp> =
         let maxWallTime = (1L <<< 48) - 1L
@@ -102,3 +111,54 @@ let ``WriteTo and ReadFrom form a round-trip`` (wallTimeMs: int64) (counter: uin
     let unpacked = HlcTimestamp.ReadFrom(System.ReadOnlySpan<byte>(buffer))
     
     unpacked = original
+
+/// Property: Packing masks counter/nodeId to their bit-widths (12-bit counter, 4-bit node)
+[<Property>]
+let ``ToPackedInt64 truncates counter and node id`` (wallTimeMs: int64) (counter: uint16) (nodeId: uint16) =
+    let safeWallTimeMs = abs wallTimeMs % (1L <<< 47) // avoid sign-bit issues when casting packed to long
+    let original = HlcTimestamp(safeWallTimeMs, counter, nodeId)
+    let unpacked = HlcTimestamp.FromPackedInt64(original.ToPackedInt64())
+
+    unpacked.WallTimeMs = safeWallTimeMs
+    && unpacked.Counter = (counter &&& 0x0FFFus)
+    && unpacked.NodeId = (nodeId &&& 0x000Fus)
+
+/// Property: String representation round-trips through Parse
+[<Property(Arbitrary = [| typeof<HlcTimestampArb> |])>]
+let ``ToString and Parse round-trip`` (ts: HlcTimestamp) =
+    HlcTimestamp.Parse(ts.ToString()) = ts
+
+/// Property: String representation round-trips through TryParse
+[<Property(Arbitrary = [| typeof<HlcTimestampArb> |])>]
+let ``ToString and TryParse round-trip`` (ts: HlcTimestamp) =
+    let ok, parsed = HlcTimestamp.TryParse(ts.ToString().AsSpan())
+    ok && parsed = ts
+
+/// Property: TryParse never throws and only returns true when output is stable
+[<Property>]
+let ``TryParse is non-throwing`` (s: string) =
+    try
+        let ok, parsed = HlcTimestamp.TryParse(s.AsSpan())
+        (not ok) || (parsed.ToString() = s)
+    with
+    | _ -> false
+
+/// Property: Operators are consistent with CompareTo
+[<Property(Arbitrary = [| typeof<HlcTimestampArb> |])>]
+let ``Operators are consistent with CompareTo`` (a: HlcTimestamp) (b: HlcTimestamp) =
+    (a < b) = (a.CompareTo(b) < 0)
+    && (a > b) = (a.CompareTo(b) > 0)
+    && (a <= b) = (a.CompareTo(b) <= 0)
+    && (a >= b) = (a.CompareTo(b) >= 0)
+
+/// Property: Big-endian encoding preserves ordering under lexicographic byte comparison
+[<Property(Arbitrary = [| typeof<HlcTimestampArb> |])>]
+let ``WriteTo encoding preserves lexicographic ordering`` (a: HlcTimestamp) (b: HlcTimestamp) =
+    let bufferA = Array.zeroCreate<byte> 10
+    let bufferB = Array.zeroCreate<byte> 10
+    a.WriteTo(Span<byte>(bufferA))
+    b.WriteTo(Span<byte>(bufferB))
+
+    let cmpTs = a.CompareTo(b)
+    let cmpBytes = compareBytesLex bufferA bufferB
+    sign cmpTs = sign cmpBytes


### PR DESCRIPTION
**HlcTimestampProperties.fs:**
- `ToPackedInt64` truncates counter and node id — verifies packed 64-bit encoding masks Counter to 12 bits and `NodeId` to 4 bits (and preserves wall time in the tested domain).
- `ToString` and Parse round-trip — `Parse(ts.ToString( )) = ts`.
- `ToString` and `TryParse` round-trip — `TryParse(ts.ToString( ))` succeeds and yields original value.
- `TryParse` is non-throwing — `TryParse(string?, out VectorClockMessageHeader)` never throws for arbitrary input strings (and if it returns true, `parsed.ToString( )` matches the input).
- Operators are consistent with `CompareTo` — <, >, <=, >= results match `CompareTo(HlcTimestamp)`.
- `WriteTo` encoding preserves lexicographic ordering — big-endian 10-byte encoding compares lexicographically the same way as `CompareTo(HlcTimestamp)`.

**VectorClockProperties.fs:**
- `Merge` returns the upper bound when one input dominates — if a <= b then `a.Merge(b) = b`, if a >= b then `a.Merge(b) = a`, concurrent case ignored.
- `Merge` is monotone with respect to inputs — merged result is never Before either input.
- `Increment` is stable under merge with original — `clock.Merge(clock.Increment(nodeId))` = incremented and symmetric.
