### PR TITLE
include dotnet installation step + optimize setup/maintenance harness

### DIFF
--- a/eng/README.md
+++ b/eng/README.md
@@ -1,0 +1,125 @@
+# Cloud Agent Setup Scripts
+
+This directory contains scripts for setting up and maintaining the Clockworks development environment in cloud-based AI agent environments (e.g., GitHub Codespaces, cloud IDEs, CI/CD runners).
+
+## Scripts
+
+### `cloud-agent-install.sh`
+
+**Purpose**: Full environment setup and initialization
+
+**When to use**: 
+- First-time environment setup
+- Clean environment initialization
+- System dependencies need to be installed or updated
+
+**What it does**:
+1. Installs required OS packages (build tools, libraries)
+2. Installs .NET SDK 10.0 if not present
+3. Creates `/etc/profile.d/dotnet-cloud-agent.sh` profile script
+4. Configures `.bashrc` for interactive shells
+5. Restores NuGet packages, workloads, and .NET tools
+
+**Requirements**:
+- `sudo` access (for system packages and profile script installation)
+- Internet connectivity (for package downloads and .NET SDK)
+
+**Usage**:
+```bash
+./eng/cloud-agent-install.sh
+```
+
+### `cloud-agent-start.sh`
+
+**Purpose**: Quick startup and maintenance
+
+**When to use**:
+- Starting a new shell session
+- Refreshing environment variables
+- Running routine package restores
+
+**What it does**:
+1. Creates profile script if missing (best-effort, requires sudo)
+2. Sources `/etc/profile.d/dotnet-cloud-agent.sh` to set environment variables
+3. Verifies .NET installation
+4. Performs quick `dotnet restore` if in a git repository
+
+**Requirements**:
+- None (degrades gracefully without sudo or .NET)
+
+**Usage**:
+```bash
+./eng/cloud-agent-start.sh
+```
+
+## Architecture
+
+### Profile Script Template (`dotnet-profile-template.sh`)
+
+The unified profile template provides:
+
+- **Deterministic .NET configuration**: Disables telemetry, suppresses logos
+- **Stable NuGet package cache**: Uses `$HOME/.nuget/packages`
+- **Idempotent PATH management**: Prevents duplicate entries on repeated sourcing
+- **Runtime detection**: Automatically finds .NET in user-local or system locations
+
+The template is used by both install and start scripts to ensure consistency.
+
+### Common Functions (`common.sh`)
+
+Shared utility functions:
+
+- `resolve_dotnet()`: Locates .NET runtime with fallback logic
+  1. User-local installation (`$HOME/.dotnet/dotnet`)
+  2. System PATH
+  3. System-wide installation (`/usr/share/dotnet/dotnet`)
+
+## Design Goals
+
+1. **Deterministic**: Same script runs produce same environment state
+2. **Idempotent**: Safe to run multiple times without side effects
+3. **Resilient**: Graceful degradation when resources unavailable
+4. **Non-interactive**: Works in CI/CD and automated environments
+5. **Fast**: Minimal overhead for startup scripts
+
+## Environment Variables
+
+The profile script sets:
+
+- `DOTNET_CLI_TELEMETRY_OPTOUT=1`: Disable telemetry
+- `DOTNET_NOLOGO=1`: Suppress .NET logo
+- `DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1`: Skip first-run experience
+- `NUGET_PACKAGES=$HOME/.nuget/packages`: Stable package cache location
+- `DOTNET_ROOT`: .NET installation directory (auto-detected)
+- `PATH`: Prepends .NET root and tools (idempotent)
+
+## Target Platforms
+
+These scripts target:
+- GitHub Codespaces
+- Cloud-based AI coding agents
+- Ubuntu-based container environments
+- CI/CD runners with Debian/Ubuntu base images
+
+## Troubleshooting
+
+**"sudo: a terminal is required to read the password"**
+- The start script degrades gracefully when sudo is unavailable
+- Run the install script manually when you have interactive sudo access
+
+**".NET not found"**
+- Verify `/etc/profile.d/dotnet-cloud-agent.sh` exists and is readable
+- Check `$HOME/.dotnet/dotnet` or `/usr/share/dotnet/dotnet` exist
+- Run `cloud-agent-install.sh` to install .NET
+
+**"PATH keeps growing"**
+- This is fixed in the current version using idempotent PATH management
+- Source the profile script multiple times to verify: `source /etc/profile.d/dotnet-cloud-agent.sh`
+
+## Maintenance
+
+When updating the scripts:
+1. Keep `dotnet-profile-template.sh` as the single source of truth
+2. Use `common.sh` for shared logic
+3. Run `shellcheck` on all scripts before committing
+4. Test idempotency: running scripts multiple times should be safe

--- a/eng/cloud-agent-start.sh
+++ b/eng/cloud-agent-start.sh
@@ -38,8 +38,12 @@ if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   cd "$(git rev-parse --show-toplevel)"
 
   if [[ -n "$dotnet_cmd" ]]; then
-    # Optional warm-up; show stderr if restore fails
-    "$dotnet_cmd" restore 2>&1 || echo "[start] warning: dotnet restore failed (check output above)"
+    # Optional warm-up; capture output and show on failure
+    if ! restore_output=$("$dotnet_cmd" restore 2>&1); then
+      restore_status=$?
+      echo "$restore_output"
+      echo "[start] warning: dotnet restore failed (exit code $restore_status)"
+    fi
   else
     echo "[start] warning: skipping dotnet restore (dotnet not found)"
   fi

--- a/eng/cloud-agent-start.sh
+++ b/eng/cloud-agent-start.sh
@@ -2,8 +2,10 @@
 set -euo pipefail
 
 dotnet_profile="/etc/profile.d/dotnet-cloud-agent.sh"
-if [ ! -f "$dotnet_profile" ]; then
-  if command -v sudo >/dev/null 2>&1; then
+
+# Ensure profile exists if possible (best-effort)
+if [[ ! -f "$dotnet_profile" ]]; then
+  if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
     tmp="$(mktemp)"
     cat >"$tmp" <<'EOF'
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
@@ -19,46 +21,48 @@ if [ -z "${DOTNET_ROOT:-}" ]; then
   fi
 fi
 
-export PATH="$DOTNET_ROOT:$PATH:$HOME/.dotnet/tools"
+export PATH="$DOTNET_ROOT:$HOME/.dotnet/tools:$PATH"
 EOF
     sudo install -m 0644 "$tmp" "$dotnet_profile"
     rm -f "$tmp"
   else
-    echo "[start] warning: missing $dotnet_profile and sudo is unavailable"
+    echo "[start] warning: missing $dotnet_profile and sudo is unavailable/non-interactive"
   fi
 fi
 
-source "$dotnet_profile" || true
-
-if ! command -v dotnet >/dev/null 2>&1; then
-  if [ -x "$HOME/.dotnet/dotnet" ]; then
-    export DOTNET_ROOT="$HOME/.dotnet"
-    export PATH="$DOTNET_ROOT:$PATH:$HOME/.dotnet/tools"
-  elif [ -x "/usr/share/dotnet/dotnet" ]; then
-    export DOTNET_ROOT="/usr/share/dotnet"
-    export PATH="$DOTNET_ROOT:$PATH:$HOME/.dotnet/tools"
-  fi
-fi
-
-if command -v dotnet >/dev/null 2>&1; then
-  echo "[start] dotnet: $(dotnet --version)"
+# Source profile if readable (avoid set -e footguns)
+if [[ -r "$dotnet_profile" ]]; then
+  # shellcheck disable=SC1090
+  source "$dotnet_profile"
 else
-  echo "[start] warning: dotnet not found on PATH"
+  echo "[start] warning: $dotnet_profile not readable; continuing"
+fi
+
+# Resolve dotnet in a robust way
+dotnet_cmd=""
+if [[ -x "$HOME/.dotnet/dotnet" ]]; then
+  dotnet_cmd="$HOME/.dotnet/dotnet"
+elif command -v dotnet >/dev/null 2>&1; then
+  dotnet_cmd="dotnet"
+elif [[ -x "/usr/share/dotnet/dotnet" ]]; then
+  dotnet_cmd="/usr/share/dotnet/dotnet"
+fi
+
+if [[ -n "$dotnet_cmd" ]]; then
+  echo "[start] dotnet: $("$dotnet_cmd" --version)"
+else
+  echo "[start] warning: dotnet not found"
 fi
 
 if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   cd "$(git rev-parse --show-toplevel)"
 
-  # Optional: quick restore if you want “always ready”
-  # (If you find this slows startup too much, remove it.)
-  if command -v dotnet >/dev/null 2>&1; then
-    dotnet restore >/dev/null
+  if [[ -n "$dotnet_cmd" ]]; then
+    # Optional warm-up; don’t fail startup if restore fails
+    "$dotnet_cmd" restore >/dev/null 2>&1 || echo "[start] warning: dotnet restore failed"
   else
     echo "[start] warning: skipping dotnet restore (dotnet not found)"
   fi
-
-  # Optional: build warm-up (I usually avoid this on start; do it only if you like)
-  # dotnet build -c Release -v minimal >/dev/null
 fi
 
 echo "[start] ready"

--- a/eng/cloud-agent-start.sh
+++ b/eng/cloud-agent-start.sh
@@ -1,30 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Source common functions
+# shellcheck disable=SC1091
+source "$(dirname "${BASH_SOURCE[0]}")/common.sh"
+
 dotnet_profile="/etc/profile.d/dotnet-cloud-agent.sh"
 
 # Ensure profile exists if possible (best-effort)
 if [[ ! -f "$dotnet_profile" ]]; then
   if command -v sudo >/dev/null 2>&1 && sudo -n true 2>/dev/null; then
-    tmp="$(mktemp)"
-    cat >"$tmp" <<'EOF'
-export DOTNET_CLI_TELEMETRY_OPTOUT=1
-export DOTNET_NOLOGO=1
-export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
-export NUGET_PACKAGES="$HOME/.nuget/packages"
-
-if [ -z "${DOTNET_ROOT:-}" ]; then
-  if [ -x "$HOME/.dotnet/dotnet" ]; then
-    export DOTNET_ROOT="$HOME/.dotnet"
-  else
-    export DOTNET_ROOT="/usr/share/dotnet"
-  fi
-fi
-
-export PATH="$DOTNET_ROOT:$HOME/.dotnet/tools:$PATH"
-EOF
-    sudo install -m 0644 "$tmp" "$dotnet_profile"
-    rm -f "$tmp"
+    script_dir="$(dirname "${BASH_SOURCE[0]}")"
+    sudo install -m 0644 "$script_dir/dotnet-profile-template.sh" "$dotnet_profile"
   else
     echo "[start] warning: missing $dotnet_profile and sudo is unavailable/non-interactive"
   fi
@@ -38,15 +25,8 @@ else
   echo "[start] warning: $dotnet_profile not readable; continuing"
 fi
 
-# Resolve dotnet in a robust way
-dotnet_cmd=""
-if [[ -x "$HOME/.dotnet/dotnet" ]]; then
-  dotnet_cmd="$HOME/.dotnet/dotnet"
-elif command -v dotnet >/dev/null 2>&1; then
-  dotnet_cmd="dotnet"
-elif [[ -x "/usr/share/dotnet/dotnet" ]]; then
-  dotnet_cmd="/usr/share/dotnet/dotnet"
-fi
+# Resolve dotnet command using common function
+dotnet_cmd="$(resolve_dotnet)"
 
 if [[ -n "$dotnet_cmd" ]]; then
   echo "[start] dotnet: $("$dotnet_cmd" --version)"
@@ -58,8 +38,8 @@ if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
   cd "$(git rev-parse --show-toplevel)"
 
   if [[ -n "$dotnet_cmd" ]]; then
-    # Optional warm-up; don’t fail startup if restore fails
-    "$dotnet_cmd" restore >/dev/null 2>&1 || echo "[start] warning: dotnet restore failed"
+    # Optional warm-up; show stderr if restore fails
+    "$dotnet_cmd" restore 2>&1 || echo "[start] warning: dotnet restore failed (check output above)"
   else
     echo "[start] warning: skipping dotnet restore (dotnet not found)"
   fi

--- a/eng/common.sh
+++ b/eng/common.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Common functions for cloud agent scripts
+
+# Resolve dotnet command with fallback logic
+# Returns the path to dotnet executable or empty string if not found
+resolve_dotnet() {
+  local dotnet_cmd=""
+  if [[ -x "$HOME/.dotnet/dotnet" ]]; then
+    dotnet_cmd="$HOME/.dotnet/dotnet"
+  elif command -v dotnet >/dev/null 2>&1; then
+    dotnet_cmd="dotnet"
+  elif [[ -x "/usr/share/dotnet/dotnet" ]]; then
+    dotnet_cmd="/usr/share/dotnet/dotnet"
+  fi
+  echo "$dotnet_cmd"
+}

--- a/eng/dotnet-profile-template.sh
+++ b/eng/dotnet-profile-template.sh
@@ -1,0 +1,26 @@
+export DOTNET_CLI_TELEMETRY_OPTOUT=1
+export DOTNET_NOLOGO=1
+export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
+
+# Keep NuGet packages in a stable path (fast incremental restores)
+export NUGET_PACKAGES="$HOME/.nuget/packages"
+
+if [ -z "${DOTNET_ROOT:-}" ]; then
+  if [ -x "$HOME/.dotnet/dotnet" ]; then
+    export DOTNET_ROOT="$HOME/.dotnet"
+  else
+    export DOTNET_ROOT="/usr/share/dotnet"
+  fi
+fi
+
+# Idempotent PATH configuration - only add if not already present
+_add_to_path() {
+  case ":$PATH:" in
+    *:"$1":*) ;;
+    *) export PATH="$1:$PATH" ;;
+  esac
+}
+
+_add_to_path "$DOTNET_ROOT"
+_add_to_path "$HOME/.dotnet/tools"
+unset -f _add_to_path

--- a/eng/dotnet-profile-template.sh
+++ b/eng/dotnet-profile-template.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # shellcheck shell=bash
 # Profile script template for cloud agent environments
 # This file is sourced, not executed directly
@@ -9,8 +10,8 @@ export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 # Keep NuGet packages in a stable path (fast incremental restores)
 export NUGET_PACKAGES="$HOME/.nuget/packages"
 
-if [ -z "${DOTNET_ROOT:-}" ]; then
-  if [ -x "$HOME/.dotnet/dotnet" ]; then
+if [[ -z "${DOTNET_ROOT:-}" ]]; then
+  if [[ -x "$HOME/.dotnet/dotnet" ]]; then
     export DOTNET_ROOT="$HOME/.dotnet"
   else
     export DOTNET_ROOT="/usr/share/dotnet"

--- a/eng/dotnet-profile-template.sh
+++ b/eng/dotnet-profile-template.sh
@@ -18,13 +18,15 @@ if [ -z "${DOTNET_ROOT:-}" ]; then
 fi
 
 # Idempotent PATH configuration - only add if not already present
-_add_to_path() {
-  case ":$PATH:" in
-    *:"$1":*) ;;
-    *) export PATH="$1:$PATH" ;;
-  esac
-}
+# Define function only if it doesn't exist (safe for multiple sourcings)
+if ! declare -F _add_to_path >/dev/null 2>&1; then
+  _add_to_path() {
+    case ":$PATH:" in
+      *:"$1":*) ;;
+      *) export PATH="$1:$PATH" ;;
+    esac
+  }
+fi
 
 _add_to_path "$DOTNET_ROOT"
 _add_to_path "$HOME/.dotnet/tools"
-unset -f _add_to_path

--- a/eng/dotnet-profile-template.sh
+++ b/eng/dotnet-profile-template.sh
@@ -1,3 +1,7 @@
+# shellcheck shell=bash
+# Profile script template for cloud agent environments
+# This file is sourced, not executed directly
+
 export DOTNET_CLI_TELEMETRY_OPTOUT=1
 export DOTNET_NOLOGO=1
 export DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1


### PR DESCRIPTION
Summary

This PR makes the cloud Codex/agent environment setup deterministic, idempotent, and resilient across non-interactive shells.

Previously, .net was not guaranteed to be installed, and repeated sourcing of the profile script could lead to PATH growth and inconsistent runtime resolution.

This change ensures:

- Deterministic installation of the latest .NET 10 SDK patch via dotnet-install.sh
- Stable DOTNET_ROOT resolution
- Idempotent PATH configuration (no duplication on repeated sourcing)
- Safe handling under `set -euo pipefail`
- Explicit runtime resolution fallback in maintenance script
- Clean startup behavior even in non-login shells