### PR TITLE
Refinements: clarify HLC packing, optimize VectorClock coordinator, simplify deterministic simulation

### DIFF
--- a/src/Distributed/HlcTimestamp.cs
+++ b/src/Distributed/HlcTimestamp.cs
@@ -20,6 +20,31 @@ namespace Clockworks.Distributed;
 public readonly record struct HlcTimestamp : IComparable<HlcTimestamp>, IComparable
 {
     /// <summary>
+    /// Number of bits allocated to the wall time component in <see cref="ToPackedInt64"/>.
+    /// </summary>
+    public const int PackedWallTimeBits = 48;
+
+    /// <summary>
+    /// Number of bits allocated to the counter component in <see cref="ToPackedInt64"/>.
+    /// </summary>
+    public const int PackedCounterBits = 12;
+
+    /// <summary>
+    /// Number of bits allocated to node id in <see cref="ToPackedInt64"/>.
+    /// </summary>
+    public const int PackedNodeIdBits = 4;
+
+    /// <summary>
+    /// Bit mask applied to <see cref="Counter"/> in <see cref="ToPackedInt64"/>.
+    /// </summary>
+    public const ushort PackedCounterMask = 0x0FFF;
+
+    /// <summary>
+    /// Bit mask applied to <see cref="NodeId"/> in <see cref="ToPackedInt64"/>.
+    /// </summary>
+    public const ushort PackedNodeIdMask = 0x000F;
+
+    /// <summary>
     /// Logical wall time in milliseconds since Unix epoch.
     /// May drift ahead of physical time to maintain causality.
     /// </summary>
@@ -52,16 +77,23 @@ public readonly record struct HlcTimestamp : IComparable<HlcTimestamp>, ICompara
 
     /// <summary>
     /// Packs the timestamp into a 64-bit value for efficient storage/transmission.
-    /// Layout: [48 bits wall time][12 bits counter][4 bits node (truncated)]
+    /// Layout: [48 bits wall time][12 bits counter][4 bits node id].
     /// </summary>
+    /// <remarks>
+    /// This packed encoding is an optimization format.
+    /// <para>
+    /// <see cref="NodeId"/> is truncated to the lower 4 bits (0-15).
+    /// Use <see cref="WriteTo"/> / <see cref="ReadFrom"/> for a full-fidelity encoding.
+    /// </para>
+    /// </remarks>
     public long ToPackedInt64()
     {
         // 48 bits for timestamp (good until year 10889)
         // 12 bits for counter (0-4095)
         // 4 bits for node ID (0-15, use for small clusters)
         ulong wall = (ulong)WallTimeMs;
-        ulong counter = (ulong)(Counter & 0x0FFF);
-        ulong node = (ulong)(NodeId & 0x000F);
+        ulong counter = (ulong)(Counter & PackedCounterMask);
+        ulong node = (ulong)(NodeId & PackedNodeIdMask);
 
         ulong packed = (wall << 16) | (counter << 4) | node;
         return unchecked((long)packed);

--- a/src/Distributed/HlcTimestamp.cs
+++ b/src/Distributed/HlcTimestamp.cs
@@ -104,10 +104,11 @@ public readonly record struct HlcTimestamp : IComparable<HlcTimestamp>, ICompara
     /// </summary>
     public static HlcTimestamp FromPackedInt64(long packed)
     {
+        var u = unchecked((ulong)packed);
         return new HlcTimestamp(
-            wallTimeMs: packed >> 16,
-            counter: (ushort)((packed >> 4) & 0xFFF),
-            nodeId: (ushort)(packed & 0xF)
+            wallTimeMs: (long)((u >> 16) & ((1UL << PackedWallTimeBits) - 1UL)),
+            counter: (ushort)((u >> PackedNodeIdBits) & PackedCounterMask),
+            nodeId: (ushort)(u & PackedNodeIdMask)
         );
     }
 

--- a/src/Distributed/VectorClockBuilder.cs
+++ b/src/Distributed/VectorClockBuilder.cs
@@ -1,0 +1,161 @@
+using System.Buffers.Binary;
+
+namespace Clockworks.Distributed;
+
+internal sealed class VectorClockBuilder
+{
+    private const int MaxEntries = ushort.MaxValue + 1;
+
+    private ushort[] _nodeIds;
+    private ulong[] _counters;
+    private int _count;
+
+    public VectorClockBuilder(int initialCapacity = 4)
+    {
+        if (initialCapacity < 0)
+            throw new ArgumentOutOfRangeException(nameof(initialCapacity));
+
+        _nodeIds = initialCapacity == 0 ? [] : new ushort[initialCapacity];
+        _counters = initialCapacity == 0 ? [] : new ulong[initialCapacity];
+        _count = 0;
+    }
+
+    public bool IsEmpty => _count == 0;
+
+    public void Reset(VectorClock snapshot)
+    {
+        var count = snapshot.Count;
+        EnsureCapacity(count);
+        _count = count;
+
+        if (count == 0)
+            return;
+
+        snapshot.CopyTo(_nodeIds.AsSpan(0, count), _counters.AsSpan(0, count));
+    }
+
+    public void Increment(ushort nodeId)
+    {
+        if (_count == 0)
+        {
+            EnsureCapacity(1);
+            _nodeIds[0] = nodeId;
+            _counters[0] = 1;
+            _count = 1;
+            return;
+        }
+
+        var index = Array.BinarySearch(_nodeIds, 0, _count, nodeId);
+        if (index >= 0)
+        {
+            _counters[index]++;
+            return;
+        }
+
+        if (_count >= MaxEntries)
+            throw new InvalidOperationException($"Cannot increment: vector clock at max capacity ({MaxEntries})");
+
+        var insertIndex = ~index;
+        EnsureCapacity(_count + 1);
+
+        if (insertIndex < _count)
+        {
+            Array.Copy(_nodeIds, insertIndex, _nodeIds, insertIndex + 1, _count - insertIndex);
+            Array.Copy(_counters, insertIndex, _counters, insertIndex + 1, _count - insertIndex);
+        }
+
+        _nodeIds[insertIndex] = nodeId;
+        _counters[insertIndex] = 1;
+        _count++;
+    }
+
+    public void Merge(VectorClock other)
+    {
+        if (other.IsEmpty)
+            return;
+
+        // Decode directly from canonical binary format to avoid reliance on VectorClock internals.
+        // This is linear in number of entries and does not allocate per entry.
+        var size = other.GetBinarySize();
+        byte[]? pooled = null;
+        Span<byte> buffer = size <= 1024 ? stackalloc byte[size] : (pooled = new byte[size]);
+
+        other.WriteTo(buffer);
+
+        var count = BinaryPrimitives.ReadUInt32BigEndian(buffer);
+        var offset = 4;
+        for (var i = 0; i < count; i++)
+        {
+            var nodeId = BinaryPrimitives.ReadUInt16BigEndian(buffer.Slice(offset, 2));
+            offset += 2;
+            var counter = BinaryPrimitives.ReadUInt64BigEndian(buffer.Slice(offset, 8));
+            offset += 8;
+
+            MergeEntry(nodeId, counter);
+        }
+    }
+
+    public VectorClock ToSnapshot()
+    {
+        if (_count == 0)
+            return new VectorClock();
+
+        var nodeIds = new ushort[_count];
+        var counters = new ulong[_count];
+        Array.Copy(_nodeIds, nodeIds, _count);
+        Array.Copy(_counters, counters, _count);
+        return VectorClock.CreateUnsafe(nodeIds, counters);
+    }
+
+    private void MergeEntry(ushort nodeId, ulong counter)
+    {
+        if (_count == 0)
+        {
+            EnsureCapacity(1);
+            _nodeIds[0] = nodeId;
+            _counters[0] = counter;
+            _count = 1;
+            return;
+        }
+
+        var index = Array.BinarySearch(_nodeIds, 0, _count, nodeId);
+        if (index >= 0)
+        {
+            if (counter > _counters[index])
+                _counters[index] = counter;
+            return;
+        }
+
+        if (_count >= MaxEntries)
+            throw new InvalidOperationException($"Cannot merge: vector clock at max capacity ({MaxEntries})");
+
+        var insertIndex = ~index;
+        EnsureCapacity(_count + 1);
+
+        if (insertIndex < _count)
+        {
+            Array.Copy(_nodeIds, insertIndex, _nodeIds, insertIndex + 1, _count - insertIndex);
+            Array.Copy(_counters, insertIndex, _counters, insertIndex + 1, _count - insertIndex);
+        }
+
+        _nodeIds[insertIndex] = nodeId;
+        _counters[insertIndex] = counter;
+        _count++;
+    }
+
+    private void EnsureCapacity(int needed)
+    {
+        if (needed > MaxEntries)
+            throw new InvalidOperationException($"Vector clock cannot contain more than {MaxEntries} entries.");
+
+        if (_nodeIds.Length >= needed)
+            return;
+
+        var next = Math.Max(needed, _nodeIds.Length == 0 ? 4 : _nodeIds.Length * 2);
+        if (next > MaxEntries)
+            next = MaxEntries;
+
+        Array.Resize(ref _nodeIds, next);
+        Array.Resize(ref _counters, next);
+    }
+}

--- a/src/Distributed/VectorClockBuilder.cs
+++ b/src/Distributed/VectorClockBuilder.cs
@@ -13,8 +13,7 @@ internal sealed class VectorClockBuilder
 
     public VectorClockBuilder(int initialCapacity = 4)
     {
-        if (initialCapacity < 0)
-            throw new ArgumentOutOfRangeException(nameof(initialCapacity));
+        ArgumentOutOfRangeException.ThrowIfNegative(initialCapacity);
 
         _nodeIds = initialCapacity == 0 ? [] : new ushort[initialCapacity];
         _counters = initialCapacity == 0 ? [] : new ulong[initialCapacity];

--- a/src/UuidV7Factory.cs
+++ b/src/UuidV7Factory.cs
@@ -153,7 +153,7 @@ public sealed class UuidV7Factory : IUuidV7Factory, IDisposable
                             $"Counter overflow: generated {MaxCounterValue + 1} UUIDs within millisecond {currentTimestamp}");
 
                     default:
-                        throw new ArgumentOutOfRangeException();
+                        throw new ArgumentOutOfRangeException(nameof(_effectiveOverflowBehavior));
                 }
             }
 
@@ -233,7 +233,7 @@ public sealed class UuidV7Factory : IUuidV7Factory, IDisposable
                                 $"Counter overflow: generated {MaxCounterValue + 1} UUIDs within millisecond {currentTimestamp}");
 
                         default:
-                            throw new ArgumentOutOfRangeException();
+                            throw new ArgumentOutOfRangeException(nameof(_effectiveOverflowBehavior));
                     }
                 }
                 else

--- a/src/UuidV7Factory.cs
+++ b/src/UuidV7Factory.cs
@@ -1,5 +1,6 @@
 using Clockworks.Abstractions;
 using System.Buffers.Binary;
+using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography;
 
@@ -153,7 +154,7 @@ public sealed class UuidV7Factory : IUuidV7Factory, IDisposable
                             $"Counter overflow: generated {MaxCounterValue + 1} UUIDs within millisecond {currentTimestamp}");
 
                     default:
-                        throw new ArgumentOutOfRangeException(nameof(_effectiveOverflowBehavior));
+                        throw new UnreachableException();
                 }
             }
 
@@ -233,7 +234,7 @@ public sealed class UuidV7Factory : IUuidV7Factory, IDisposable
                                 $"Counter overflow: generated {MaxCounterValue + 1} UUIDs within millisecond {currentTimestamp}");
 
                         default:
-                            throw new ArgumentOutOfRangeException(nameof(_effectiveOverflowBehavior));
+                            throw new UnreachableException();
                     }
                 }
                 else

--- a/tests/HlcTimestampTests.cs
+++ b/tests/HlcTimestampTests.cs
@@ -30,4 +30,20 @@ public sealed class HlcTimestampTests
         Assert.Equal((ushort)(ts.Counter & 0x0FFF), parsed.Counter);
         Assert.Equal((ushort)(ts.NodeId & 0x000F), parsed.NodeId);
     }
+
+    [Fact]
+    public void FromPackedInt64_DoesNotSignExtendWallTime_WhenPackedHighBitSet()
+    {
+        // Pick a 48-bit wall time where bit 47 is set; after packing (<< 16) this becomes bit 63.
+        var wall48 = (1L << 47) + 123;
+        var ts = new HlcTimestamp(wallTimeMs: wall48, counter: 1, nodeId: 2);
+
+        var packed = ts.ToPackedInt64();
+        Assert.True(packed < 0, "Packed representation should have sign bit set for this case.");
+
+        var decoded = HlcTimestamp.FromPackedInt64(packed);
+        Assert.Equal(wall48, decoded.WallTimeMs);
+        Assert.Equal((ushort)1, decoded.Counter);
+        Assert.Equal((ushort)2, decoded.NodeId);
+    }
 }


### PR DESCRIPTION
## Summary

This PR refines several distributed-systems demo and library implementation details to be more explicit and efficient [closer to “systems library” standards], while preserving existing behavior and wire formats.

`HlcTimestamp`:
- Clarified packed `Int64` encoding semantics [explicit constant + XML docs]
- Made `NodeId` truncation in packed  form explicit; full-fidelity remains `WriteTo(Span<byte>)` and `ReadFrom(ReadOnlySpan<byte>)`

`VectorClock` and `VectorClockCoordinator`:
- Added `IsEmpty` for explicit checks
- Added internal helpers to support efficient snapshotting
-  Added internal `VectorClockBuilder` and updated `VectorClockCoordinator` to use it to reduce allocation churn on merge/increment hot paths
- Clarified canonical binary wire format docs [big-endian, sorted/canonical output]

Deterministic distributed showcase demo:
- Switched from `ConcurrentDictionary` to `Dictionary` / `HashSet` [since the initial demo is single-threaded by design]
- Reworked simulated network in-flight scheduling to a `PriorityQueue` with deterministic tie-breaking
- Modeled reordering as bounded delivery-time jitter clamped to >= for now [time-driven delivery preserved]