### PR TITLE
Expose UUIDv7 factory statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,14 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+### Added
+- Add opt-in `UuidV7FactoryStatistics` counters for generated UUIDs, clock rollback, counter overflow, spin-wait, logical drift, CAS retries, and random-buffer refills.
+
 ### Changed
 - `HlcGuidFactory` constructor now enforces a 14-bit node ID constraint and throws `ArgumentOutOfRangeException` for values above `HlcGuidFactory.MaxNodeId` (16383). Previously, higher values were silently truncated in generated UUIDv7 values.
 
 ### Documentation
+- Document UUIDv7 factory statistics and counter semantics.
 - Clarify `UuidV7Factory` collision and clock-skew guarantees, including the distinction between per-instance deterministic monotonicity and probabilistic cross-factory uniqueness.
 - Document the custom RNG contract for `UuidV7Factory`, including deterministic replay behavior and production CSPRNG guidance.
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ It is built around `TimeProvider` so that *time becomes an injectable dependency
   - `UuidV7Factory` produces RFC 9562 UUIDv7 values as `Guid`
   - Works with real or simulated time
   - Configurable counter overflow behavior
+  - Optional statistics for rollback, overflow, spin-wait, contention, and random-buffer refill diagnostics
   - Per-instance monotonicity under clock rollback; cross-factory uniqueness remains probabilistic unless coordinated externally
 
 - **Hybrid Logical Clock (HLC)**
@@ -35,7 +36,7 @@ It is built around `TimeProvider` so that *time becomes an injectable dependency
   - Canonical binary wire format (`VectorClock.WriteTo`/`ReadFrom`) and string form for HTTP/gRPC headers
 
 - **Lightweight instrumentation**
-  - Counters for timers, advances, and timeouts useful in simulation/test assertions
+  - Counters for timers, advances, timeouts, and UUIDv7 factory behavior useful in simulation/test assertions
 
 ## Installation
 

--- a/demo/Clockworks.Demo/Demos/UuidV7Showcase.cs
+++ b/demo/Clockworks.Demo/Demos/UuidV7Showcase.cs
@@ -1,6 +1,7 @@
 using System.Diagnostics;
 using Clockworks;
 using Clockworks.Distributed;
+using Clockworks.Instrumentation;
 
 namespace Clockworks.Demo.Demos;
 
@@ -194,6 +195,7 @@ internal static class UuidV7Showcase
 
         Console.WriteLine();
         Console.WriteLine("Lock-Free Factory (single-threaded):");
+        double disabledNsPerOp;
         using (var factory = new UuidV7Factory(TimeProvider.System))
         {
             var sw = Stopwatch.StartNew();
@@ -206,7 +208,33 @@ internal static class UuidV7Showcase
             var seconds = sw.Elapsed.TotalSeconds;
             var opsPerSec = BenchmarkIterations / seconds;
             var nsPerOp = sw.Elapsed.TotalNanoseconds / BenchmarkIterations;
+            disabledNsPerOp = nsPerOp;
             Console.WriteLine($"  {opsPerSec:N0} ops/sec ({nsPerOp:N1} ns/op)");
+        }
+
+        Console.WriteLine();
+        Console.WriteLine("Lock-Free Factory + statistics (single-threaded):");
+        {
+            var statistics = new UuidV7FactoryStatistics();
+            using var factory = new UuidV7Factory(
+                TimeProvider.System,
+                rng: null,
+                CounterOverflowBehavior.SpinWait,
+                statistics);
+
+            var sw = Stopwatch.StartNew();
+            for (int i = 0; i < BenchmarkIterations; i++)
+            {
+                _ = factory.NewGuid();
+            }
+            sw.Stop();
+
+            var seconds = sw.Elapsed.TotalSeconds;
+            var opsPerSec = BenchmarkIterations / seconds;
+            var nsPerOp = sw.Elapsed.TotalNanoseconds / BenchmarkIterations;
+            var overhead = (nsPerOp / disabledNsPerOp - 1.0) * 100.0;
+            Console.WriteLine($"  {opsPerSec:N0} ops/sec ({nsPerOp:N1} ns/op, {overhead:N1}% vs disabled)");
+            Console.WriteLine($"  Generated: {statistics.GeneratedCount:N0}, CAS retries: {statistics.CasRetryCount:N0}");
         }
 
         Console.WriteLine();

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,10 +10,14 @@ This page mirrors the repository root `CHANGELOG.md`.
 
 ## [Unreleased]
 
+### Added
+- Add opt-in `UuidV7FactoryStatistics` counters for generated UUIDs, clock rollback, counter overflow, spin-wait, logical drift, CAS retries, and random-buffer refills.
+
 ### Changed
 - `HlcGuidFactory` constructor now enforces a 14-bit node ID constraint and throws `ArgumentOutOfRangeException` for values above `HlcGuidFactory.MaxNodeId` (16383). Previously, higher values were silently truncated in generated UUIDv7 values.
 
 ### Documentation
+- Document UUIDv7 factory statistics and counter semantics.
 - Clarify `UuidV7Factory` collision and clock-skew guarantees, including the distinction between per-instance deterministic monotonicity and probabilistic cross-factory uniqueness.
 - Document the custom RNG contract for `UuidV7Factory`, including deterministic replay behavior and production CSPRNG guidance.
 

--- a/docs/guide/instrumentation.md
+++ b/docs/guide/instrumentation.md
@@ -53,7 +53,7 @@ Console.WriteLine(snapshot.ClockRollbackCount);
 Console.WriteLine(snapshot.CasRetryCount);
 ```
 
-Statistics are disabled unless you pass an instance to the factory. When enabled, counters use atomic operations so they can be read safely while UUIDs are being generated concurrently.
+Statistics are disabled unless you pass an instance to the factory. When enabled, counters use atomic operations so they can be read safely while UUIDs are being generated concurrently. `Snapshot()` and `Reset()` operate counter-by-counter; they are suitable for diagnostics and phase-isolated tests, not as a linearizable multi-counter transaction.
 
 Useful counters include:
 

--- a/docs/guide/instrumentation.md
+++ b/docs/guide/instrumentation.md
@@ -33,6 +33,45 @@ You can reset counters between test phases:
 tp.Statistics.Reset();
 ```
 
+## UUIDv7 factory statistics
+
+`UuidV7Factory` can update opt-in `UuidV7FactoryStatistics` counters:
+
+```csharp
+var stats = new UuidV7FactoryStatistics();
+using var factory = new UuidV7Factory(
+    TimeProvider.System,
+    rng: null,
+    overflowBehavior: CounterOverflowBehavior.SpinWait,
+    statistics: stats);
+
+factory.NewGuid();
+
+var snapshot = stats.Snapshot();
+Console.WriteLine(snapshot.GeneratedCount);
+Console.WriteLine(snapshot.ClockRollbackCount);
+Console.WriteLine(snapshot.CasRetryCount);
+```
+
+Statistics are disabled unless you pass an instance to the factory. When enabled, counters use atomic operations so they can be read safely while UUIDs are being generated concurrently.
+
+Useful counters include:
+
+- `GeneratedCount`
+- `ClockRollbackCount`
+- `CounterOverflowCount`
+- `SpinWaitCount`
+- `LogicalTimestampAdvanceCount`
+- `MaxLogicalDriftMs`
+- `CasRetryCount`
+- `RandomBufferRefillCount`
+
+Use `Snapshot()` when you need a point-in-time value object, and `Reset()` to isolate test phases:
+
+```csharp
+stats.Reset();
+```
+
 ## Timeout statistics
 
 Timeout factory helpers (`Timeouts`) can record aggregate timeout activity via `TimeoutStatistics`.
@@ -58,4 +97,3 @@ If you prefer isolation per test (or per component), pass your own `TimeoutStati
 var stats = new TimeoutStatistics();
 using var handle = Timeouts.CreateTimeoutHandle(tp, TimeSpan.FromSeconds(1), stats);
 ```
-

--- a/docs/guide/uuidv7.md
+++ b/docs/guide/uuidv7.md
@@ -106,7 +106,7 @@ Key counters:
 | `CasRetryCount` | Failed compare-exchange attempts in the lock-free allocation loop. |
 | `RandomBufferRefillCount` | Thread-local random buffer refills. |
 
-Most counters are diagnostic event counts, not rates. For example, a single `NewGuids(span)` call may reserve many UUIDs with one successful allocation decision, so `GeneratedCount` increases by `span.Length` while rollback or drift counters increase once for that reservation.
+Most counters are diagnostic event counts, not rates. For example, a single `NewGuids(span)` call may reserve many UUIDs with one successful allocation decision, so `GeneratedCount` increases by `span.Length` while rollback or drift counters increase once for that reservation. Under lock-free contention, overflow and spin-wait counters describe observed path entries and wait attempts rather than a globally serialized event log.
 
 ## Custom RNGs and Deterministic Tests
 

--- a/docs/guide/uuidv7.md
+++ b/docs/guide/uuidv7.md
@@ -68,6 +68,46 @@ For production services, prefer a single `UuidV7Factory` singleton per process o
 
 For high-assurance shared namespaces, use a storage uniqueness constraint as the final guardrail and retry on conflict. If you need node-aware ordering semantics, consider `HlcGuidFactory`; it embeds a node ID and HLC timestamp, but it should be chosen for causal/node-aware ordering rather than treated as a blanket substitute for storage-level uniqueness.
 
+## Statistics
+
+`UuidV7Factory` statistics are opt-in. Leave them disabled for the lowest-overhead path, or pass a `UuidV7FactoryStatistics` instance when you want to observe clock rollback, counter overflow, spin-wait pressure, and lock-free contention:
+
+```csharp
+var stats = new UuidV7FactoryStatistics();
+using var factory = new UuidV7Factory(
+    TimeProvider.System,
+    rng: null,
+    overflowBehavior: CounterOverflowBehavior.SpinWait,
+    statistics: stats);
+
+var id = factory.NewGuid();
+var snapshot = stats.Snapshot();
+
+Console.WriteLine(snapshot.GeneratedCount);
+Console.WriteLine(snapshot.CounterOverflowCount);
+```
+
+The built-in DI helpers can register the same shared statistics object as the singleton factory:
+
+```csharp
+services.AddLockFreeGuidFactory(new UuidV7FactoryStatistics());
+```
+
+Key counters:
+
+| Counter | Meaning |
+|---|---|
+| `GeneratedCount` | Number of UUIDs successfully generated. Batch generation increments by the span length. |
+| `ClockRollbackCount` | Successful allocation decisions made while physical time was behind the factory's logical frontier. |
+| `CounterOverflowCount` | Times the 12-bit per-millisecond counter overflow path was reached. |
+| `SpinWaitCount` | Times overflow handling had to wait for physical time to advance. |
+| `LogicalTimestampAdvanceCount` | Successful allocation decisions that emitted logical time ahead of physical time. |
+| `MaxLogicalDriftMs` | Maximum observed distance between emitted logical time and physical time. |
+| `CasRetryCount` | Failed compare-exchange attempts in the lock-free allocation loop. |
+| `RandomBufferRefillCount` | Thread-local random buffer refills. |
+
+Most counters are diagnostic event counts, not rates. For example, a single `NewGuids(span)` call may reserve many UUIDs with one successful allocation decision, so `GeneratedCount` increases by `span.Length` while rollback or drift counters increase once for that reservation.
+
 ## Custom RNGs and Deterministic Tests
 
 Custom RNG injection exists so tests and simulations can replay exact UUID sequences. Clockworks does not ship a deterministic RNG implementation; provide your own test-only `RandomNumberGenerator` when you need replay.
@@ -162,3 +202,5 @@ dotnet run --project demo/Clockworks.Demo -- uuidv7-sortability
 # Benchmark mode
 dotnet run --project demo/Clockworks.Demo -- uuidv7 --bench
 ```
+
+Benchmark mode includes a side-by-side single-threaded comparison of the default hot path and statistics-enabled hot path.

--- a/property-tests/UuidV7FactoryProperties.fs
+++ b/property-tests/UuidV7FactoryProperties.fs
@@ -8,6 +8,7 @@ open Xunit
 open FsCheck
 open FsCheck.Xunit
 open Clockworks
+open Clockworks.Instrumentation
 
 type private DeterministicRandomNumberGenerator(seed: int) =
     inherit RandomNumberGenerator()
@@ -156,6 +157,47 @@ let ``UUIDs are unique`` (count: byte) =
     let uniqueCount = uuids |> Array.distinct |> Array.length
     
     uniqueCount = safeCount
+
+/// Property: UUIDv7 statistics count every successfully generated UUID exactly once.
+[<Property(MaxTest = 50)>]
+let ``Statistics generated count matches successful UUID generation`` (count: uint16) =
+    let safeCount = int (count % 512us) + 1
+    let statistics = UuidV7FactoryStatistics()
+    let timeProvider = new SimulatedTimeProvider()
+    use factory =
+        new UuidV7Factory(
+            timeProvider,
+            null,
+            CounterOverflowBehavior.IncrementTimestamp,
+            statistics)
+
+    statistics.Reset()
+
+    for _ in 1..safeCount do
+        factory.NewGuid() |> ignore
+
+    statistics.Snapshot().GeneratedCount = int64 safeCount
+
+/// Property: UUIDv7 statistics expose the maximum logical drift caused by wall-clock rollback.
+[<Property(MaxTest = 50)>]
+let ``Statistics max drift tracks wall clock rollback`` (rollbackMs: uint16) =
+    let safeRollbackMs = int64 (rollbackMs % 1000us) + 1L
+    let startMs = 1_700_000_000_000L
+    let statistics = UuidV7FactoryStatistics()
+    let timeProvider = SimulatedTimeProvider.FromUnixMs(startMs)
+    use factory = new UuidV7Factory(timeProvider, null, CounterOverflowBehavior.SpinWait, statistics)
+
+    statistics.Reset()
+
+    factory.NewGuid() |> ignore
+    timeProvider.SetUnixMs(startMs - safeRollbackMs)
+    factory.NewGuid() |> ignore
+
+    let snapshot = statistics.Snapshot()
+    snapshot.GeneratedCount = 2L
+    && snapshot.ClockRollbackCount = 1L
+    && snapshot.LogicalTimestampAdvanceCount = 1L
+    && snapshot.MaxLogicalDriftMs = safeRollbackMs
 
 /// Property: UUIDs generated at different times are different
 [<Property(MaxTest = 50)>]

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -1,5 +1,6 @@
 using Clockworks.Abstractions;
 using Clockworks.Distributed;
+using Clockworks.Instrumentation;
 using System.Security.Cryptography;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
@@ -31,6 +32,29 @@ public static class ServiceCollectionExtensions
         }
 
         /// <summary>
+        /// Adds the lock-free GUID factory with system time and opt-in statistics.
+        /// </summary>
+        /// <param name="statistics">Statistics instance updated by the registered singleton factory.</param>
+        /// <param name="overflowBehavior">Behavior to apply when the per-millisecond counter overflows.</param>
+        public IServiceCollection AddLockFreeGuidFactory(
+            UuidV7FactoryStatistics statistics,
+            CounterOverflowBehavior overflowBehavior = CounterOverflowBehavior.SpinWait)
+        {
+            ArgumentNullException.ThrowIfNull(statistics);
+
+            services.TryAddSingleton(TimeProvider.System);
+            services.AddSingleton(statistics);
+            services.AddSingleton<IUuidV7Factory>(sp => new UuidV7Factory(
+                sp.GetRequiredService<TimeProvider>(),
+                rng: null,
+                overflowBehavior: overflowBehavior,
+                statistics: sp.GetRequiredService<UuidV7FactoryStatistics>()));
+            services.AddSingleton(sp => (UuidV7Factory)sp.GetRequiredService<IUuidV7Factory>());
+
+            return services;
+        }
+
+        /// <summary>
         /// Adds the lock-free GUID factory with a custom TimeProvider.
         /// Use this for testing or simulation. Registers a singleton factory so per-instance monotonic state is shared
         /// across callers in the process.
@@ -48,6 +72,33 @@ public static class ServiceCollectionExtensions
         {
             services.TryAddSingleton(timeProvider);
             services.AddSingleton<IUuidV7Factory>(new UuidV7Factory(timeProvider, rng, overflowBehavior));
+            services.AddSingleton(sp => (UuidV7Factory)sp.GetRequiredService<IUuidV7Factory>());
+
+            return services;
+        }
+
+        /// <summary>
+        /// Adds the lock-free GUID factory with a custom TimeProvider and opt-in statistics.
+        /// </summary>
+        /// <param name="timeProvider">Time source used by the UUIDv7 factory.</param>
+        /// <param name="statistics">Statistics instance updated by the registered singleton factory.</param>
+        /// <param name="rng">
+        /// Random number generator used for the UUID random tail. Leave null for a per-factory CSPRNG. Seeded or
+        /// deterministic RNGs are intended only for reproducible tests and simulations.
+        /// </param>
+        /// <param name="overflowBehavior">Behavior to apply when the per-millisecond counter overflows.</param>
+        public IServiceCollection AddLockFreeGuidFactory(
+            TimeProvider timeProvider,
+            UuidV7FactoryStatistics statistics,
+            RandomNumberGenerator? rng = null,
+            CounterOverflowBehavior overflowBehavior = CounterOverflowBehavior.SpinWait)
+        {
+            ArgumentNullException.ThrowIfNull(timeProvider);
+            ArgumentNullException.ThrowIfNull(statistics);
+
+            services.TryAddSingleton(timeProvider);
+            services.AddSingleton(statistics);
+            services.AddSingleton<IUuidV7Factory>(new UuidV7Factory(timeProvider, rng, overflowBehavior, statistics));
             services.AddSingleton(sp => (UuidV7Factory)sp.GetRequiredService<IUuidV7Factory>());
 
             return services;

--- a/src/Extensions.cs
+++ b/src/Extensions.cs
@@ -57,7 +57,9 @@ public static class ServiceCollectionExtensions
         /// <summary>
         /// Adds the lock-free GUID factory with a custom TimeProvider.
         /// Use this for testing or simulation. Registers a singleton factory so per-instance monotonic state is shared
-        /// across callers in the process.
+        /// across callers in the process. The service provider disposes the created factory when the provider is
+        /// disposed; externally supplied <paramref name="timeProvider"/> and <paramref name="rng"/> instances remain
+        /// caller-owned.
         /// </summary>
         /// <param name="timeProvider">Time source used by the UUIDv7 factory.</param>
         /// <param name="rng">
@@ -70,8 +72,13 @@ public static class ServiceCollectionExtensions
             RandomNumberGenerator? rng = null,
             CounterOverflowBehavior overflowBehavior = CounterOverflowBehavior.SpinWait)
         {
+            ArgumentNullException.ThrowIfNull(timeProvider);
+
             services.TryAddSingleton(timeProvider);
-            services.AddSingleton<IUuidV7Factory>(new UuidV7Factory(timeProvider, rng, overflowBehavior));
+            services.AddSingleton<IUuidV7Factory>(sp => new UuidV7Factory(
+                sp.GetRequiredService<TimeProvider>(),
+                rng,
+                overflowBehavior));
             services.AddSingleton(sp => (UuidV7Factory)sp.GetRequiredService<IUuidV7Factory>());
 
             return services;
@@ -79,6 +86,8 @@ public static class ServiceCollectionExtensions
 
         /// <summary>
         /// Adds the lock-free GUID factory with a custom TimeProvider and opt-in statistics.
+        /// The service provider disposes the created factory when the provider is disposed; externally supplied
+        /// <paramref name="timeProvider"/> and <paramref name="rng"/> instances remain caller-owned.
         /// </summary>
         /// <param name="timeProvider">Time source used by the UUIDv7 factory.</param>
         /// <param name="statistics">Statistics instance updated by the registered singleton factory.</param>
@@ -98,7 +107,11 @@ public static class ServiceCollectionExtensions
 
             services.TryAddSingleton(timeProvider);
             services.AddSingleton(statistics);
-            services.AddSingleton<IUuidV7Factory>(new UuidV7Factory(timeProvider, rng, overflowBehavior, statistics));
+            services.AddSingleton<IUuidV7Factory>(sp => new UuidV7Factory(
+                sp.GetRequiredService<TimeProvider>(),
+                rng,
+                overflowBehavior,
+                sp.GetRequiredService<UuidV7FactoryStatistics>()));
             services.AddSingleton(sp => (UuidV7Factory)sp.GetRequiredService<IUuidV7Factory>());
 
             return services;

--- a/src/Instrumentation/UuidV7FactoryStatistics.cs
+++ b/src/Instrumentation/UuidV7FactoryStatistics.cs
@@ -1,0 +1,132 @@
+namespace Clockworks.Instrumentation;
+
+/// <summary>
+/// Lightweight counters for observing <see cref="UuidV7Factory"/> behavior.
+/// </summary>
+/// <remarks>
+/// Statistics are opt-in. Passing an instance to <see cref="UuidV7Factory"/> enables atomic counter updates on the
+/// UUIDv7 generation path; leaving statistics unset avoids those atomic updates.
+/// </remarks>
+public sealed class UuidV7FactoryStatistics
+{
+    private long _generatedCount;
+    private long _clockRollbackCount;
+    private long _counterOverflowCount;
+    private long _spinWaitCount;
+    private long _logicalTimestampAdvanceCount;
+    private long _maxLogicalDriftMs;
+    private long _casRetryCount;
+    private long _randomBufferRefillCount;
+
+    /// <summary>
+    /// Total number of UUIDs generated.
+    /// </summary>
+    public long GeneratedCount => Volatile.Read(ref _generatedCount);
+
+    /// <summary>
+    /// Number of successful allocation decisions made while physical time was behind the factory's logical frontier.
+    /// </summary>
+    public long ClockRollbackCount => Volatile.Read(ref _clockRollbackCount);
+
+    /// <summary>
+    /// Number of times the 12-bit per-millisecond counter overflow path was reached.
+    /// </summary>
+    public long CounterOverflowCount => Volatile.Read(ref _counterOverflowCount);
+
+    /// <summary>
+    /// Number of times generation had to wait for physical time to advance after counter overflow.
+    /// </summary>
+    public long SpinWaitCount => Volatile.Read(ref _spinWaitCount);
+
+    /// <summary>
+    /// Number of successful allocation decisions that emitted a logical timestamp ahead of physical time.
+    /// </summary>
+    public long LogicalTimestampAdvanceCount => Volatile.Read(ref _logicalTimestampAdvanceCount);
+
+    /// <summary>
+    /// Maximum observed distance, in milliseconds, between emitted logical time and physical time.
+    /// </summary>
+    public long MaxLogicalDriftMs => Volatile.Read(ref _maxLogicalDriftMs);
+
+    /// <summary>
+    /// Number of failed compare-exchange attempts in the lock-free allocation loop.
+    /// </summary>
+    public long CasRetryCount => Volatile.Read(ref _casRetryCount);
+
+    /// <summary>
+    /// Number of thread-local random buffer refills.
+    /// </summary>
+    public long RandomBufferRefillCount => Volatile.Read(ref _randomBufferRefillCount);
+
+    /// <summary>
+    /// Captures a point-in-time snapshot of all UUIDv7 factory counters.
+    /// </summary>
+    public UuidV7FactoryStatisticsSnapshot Snapshot() => new(
+        GeneratedCount,
+        ClockRollbackCount,
+        CounterOverflowCount,
+        SpinWaitCount,
+        LogicalTimestampAdvanceCount,
+        MaxLogicalDriftMs,
+        CasRetryCount,
+        RandomBufferRefillCount);
+
+    /// <summary>
+    /// Resets all counters to zero.
+    /// </summary>
+    public void Reset()
+    {
+        Interlocked.Exchange(ref _generatedCount, 0);
+        Interlocked.Exchange(ref _clockRollbackCount, 0);
+        Interlocked.Exchange(ref _counterOverflowCount, 0);
+        Interlocked.Exchange(ref _spinWaitCount, 0);
+        Interlocked.Exchange(ref _logicalTimestampAdvanceCount, 0);
+        Interlocked.Exchange(ref _maxLogicalDriftMs, 0);
+        Interlocked.Exchange(ref _casRetryCount, 0);
+        Interlocked.Exchange(ref _randomBufferRefillCount, 0);
+    }
+
+    internal void RecordGenerated(long count) => Interlocked.Add(ref _generatedCount, count);
+
+    internal void RecordClockRollback() => Interlocked.Increment(ref _clockRollbackCount);
+
+    internal void RecordCounterOverflow() => Interlocked.Increment(ref _counterOverflowCount);
+
+    internal void RecordSpinWait() => Interlocked.Increment(ref _spinWaitCount);
+
+    internal void RecordLogicalTimestampAdvance(long driftMs)
+    {
+        Interlocked.Increment(ref _logicalTimestampAdvanceCount);
+        InterlockedMax(ref _maxLogicalDriftMs, driftMs);
+    }
+
+    internal void RecordCasRetry() => Interlocked.Increment(ref _casRetryCount);
+
+    internal void RecordRandomBufferRefill() => Interlocked.Increment(ref _randomBufferRefillCount);
+
+    private static void InterlockedMax(ref long location, long value)
+    {
+        var current = Volatile.Read(ref location);
+        while (value > current)
+        {
+            var previous = Interlocked.CompareExchange(ref location, value, current);
+            if (previous == current)
+                break;
+
+            current = previous;
+        }
+    }
+}
+
+/// <summary>
+/// Point-in-time UUIDv7 factory statistics.
+/// </summary>
+public readonly record struct UuidV7FactoryStatisticsSnapshot(
+    long GeneratedCount,
+    long ClockRollbackCount,
+    long CounterOverflowCount,
+    long SpinWaitCount,
+    long LogicalTimestampAdvanceCount,
+    long MaxLogicalDriftMs,
+    long CasRetryCount,
+    long RandomBufferRefillCount);

--- a/src/Instrumentation/UuidV7FactoryStatistics.cs
+++ b/src/Instrumentation/UuidV7FactoryStatistics.cs
@@ -5,7 +5,9 @@ namespace Clockworks.Instrumentation;
 /// </summary>
 /// <remarks>
 /// Statistics are opt-in. Passing an instance to <see cref="UuidV7Factory"/> enables atomic counter updates on the
-/// UUIDv7 generation path; leaving statistics unset avoids those atomic updates.
+/// UUIDv7 generation path; leaving statistics unset avoids those atomic updates. Counters are diagnostic signals: under
+/// lock-free contention, event counters such as <see cref="CounterOverflowCount"/> and <see cref="SpinWaitCount"/>
+/// describe observed path entries and wait attempts rather than globally serialized allocation decisions.
 /// </remarks>
 public sealed class UuidV7FactoryStatistics
 {
@@ -61,19 +63,25 @@ public sealed class UuidV7FactoryStatistics
     /// <summary>
     /// Captures a point-in-time snapshot of all UUIDv7 factory counters.
     /// </summary>
+    /// <remarks>
+    /// Each field is read atomically, but the snapshot is not a linearizable transaction across all counters.
+    /// </remarks>
     public UuidV7FactoryStatisticsSnapshot Snapshot() => new(
-        GeneratedCount,
-        ClockRollbackCount,
-        CounterOverflowCount,
-        SpinWaitCount,
-        LogicalTimestampAdvanceCount,
-        MaxLogicalDriftMs,
-        CasRetryCount,
-        RandomBufferRefillCount);
+        GeneratedCount: GeneratedCount,
+        ClockRollbackCount: ClockRollbackCount,
+        CounterOverflowCount: CounterOverflowCount,
+        SpinWaitCount: SpinWaitCount,
+        LogicalTimestampAdvanceCount: LogicalTimestampAdvanceCount,
+        MaxLogicalDriftMs: MaxLogicalDriftMs,
+        CasRetryCount: CasRetryCount,
+        RandomBufferRefillCount: RandomBufferRefillCount);
 
     /// <summary>
     /// Resets all counters to zero.
     /// </summary>
+    /// <remarks>
+    /// Each counter is reset atomically, but the reset is not a linearizable transaction across all counters.
+    /// </remarks>
     public void Reset()
     {
         Interlocked.Exchange(ref _generatedCount, 0);

--- a/src/UuidV7Factory.cs
+++ b/src/UuidV7Factory.cs
@@ -1,4 +1,5 @@
 using Clockworks.Abstractions;
+using Clockworks.Instrumentation;
 using System.Buffers.Binary;
 using System.Diagnostics;
 using System.Runtime.CompilerServices;
@@ -51,6 +52,7 @@ public sealed class UuidV7Factory : IUuidV7Factory, IDisposable
     private readonly bool _ownsRng;
     private readonly CounterOverflowBehavior _overflowBehavior;
     private readonly CounterOverflowBehavior _effectiveOverflowBehavior;
+    private readonly UuidV7FactoryStatistics? _statistics;
 
     // Packed state: [48 bits timestamp][16 bits counter]
     // Using 64-bit atomic operations for lock-free updates
@@ -86,17 +88,39 @@ public sealed class UuidV7Factory : IUuidV7Factory, IDisposable
         TimeProvider timeProvider,
         RandomNumberGenerator? rng = null,
         CounterOverflowBehavior overflowBehavior = CounterOverflowBehavior.SpinWait)
+        : this(timeProvider, rng, overflowBehavior, statistics: null)
+    {
+    }
+
+    /// <summary>
+    /// Creates a new UUIDv7 generator with optional statistics.
+    /// </summary>
+    /// <param name="timeProvider">Time source (use <see cref="TimeProvider.System"/> for production).</param>
+    /// <param name="rng">
+    /// Random number generator to use for the random portion of the UUID. If <see langword="null"/>, a new
+    /// cryptographically-secure RNG is created and owned by this instance. Production deployments should use a
+    /// cryptographically strong RNG with independent state for each factory. Seeded or deterministic RNGs are intended
+    /// only for reproducible tests and simulations.
+    /// </param>
+    /// <param name="overflowBehavior">Behavior to apply when the per-millisecond counter overflows.</param>
+    /// <param name="statistics">Statistics instance to update from this factory, or <see langword="null"/> to disable statistics.</param>
+    public UuidV7Factory(
+        TimeProvider timeProvider,
+        RandomNumberGenerator? rng,
+        CounterOverflowBehavior overflowBehavior,
+        UuidV7FactoryStatistics? statistics)
     {
         _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
         _rng = rng ?? RandomNumberGenerator.Create();
         _ownsRng = rng is null;
         _overflowBehavior = overflowBehavior;
+        _statistics = statistics;
 
         _effectiveOverflowBehavior = overflowBehavior == CounterOverflowBehavior.Auto
             ? (_timeProvider is SimulatedTimeProvider ? CounterOverflowBehavior.IncrementTimestamp : CounterOverflowBehavior.SpinWait)
             : overflowBehavior;
 
-        _randomBuffer = new ThreadLocal<RandomBuffer>(() => new RandomBuffer(_rng), trackAllValues: false);
+        _randomBuffer = new ThreadLocal<RandomBuffer>(() => new RandomBuffer(_rng, _statistics), trackAllValues: false);
 
         // Initialize state with current time and random counter
         var initialTimestamp = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
@@ -104,19 +128,28 @@ public sealed class UuidV7Factory : IUuidV7Factory, IDisposable
         _packedState = PackState(initialTimestamp, initialCounter);
     }
 
+    /// <summary>
+    /// Statistics instance updated by this factory, or <see langword="null"/> when statistics are disabled.
+    /// </summary>
+    public UuidV7FactoryStatistics? Statistics => _statistics;
+
     /// <inheritdoc/>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public Guid NewGuid()
     {
         var (timestampMs, counter) = AllocateTimestampAndCounter();
-        return CreateGuidFromState(timestampMs, counter);
+        var guid = CreateGuidFromState(timestampMs, counter);
+        _statistics?.RecordGenerated(1);
+        return guid;
     }
 
     /// <inheritdoc/>
     public (Guid Guid, long TimestampMs) NewGuidWithTimestamp()
     {
         var (timestampMs, counter) = AllocateTimestampAndCounter();
-        return (CreateGuidFromState(timestampMs, counter), timestampMs);
+        var guid = CreateGuidFromState(timestampMs, counter);
+        _statistics?.RecordGenerated(1);
+        return (guid, timestampMs);
     }
 
     /// <inheritdoc/>
@@ -139,6 +172,7 @@ public sealed class UuidV7Factory : IUuidV7Factory, IDisposable
             var (currentTimestamp, currentCounter) = UnpackState(currentPacked);
 
             var physicalTime = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
+            var clockRollback = physicalTime < currentTimestamp;
 
             var baseTimestamp = physicalTime > currentTimestamp ? physicalTime : currentTimestamp;
 
@@ -149,9 +183,11 @@ public sealed class UuidV7Factory : IUuidV7Factory, IDisposable
             if (startCounter > MaxCounterValue)
             {
                 // Counter overflow at this millisecond.
+                _statistics?.RecordCounterOverflow();
                 switch (_effectiveOverflowBehavior)
                 {
                     case CounterOverflowBehavior.SpinWait:
+                        _statistics?.RecordSpinWait();
                         SpinWaitForNextMillisecond(baseTimestamp);
                         continue;
 
@@ -178,15 +214,19 @@ public sealed class UuidV7Factory : IUuidV7Factory, IDisposable
 
             if (Interlocked.CompareExchange(ref _packedState, newPacked, currentPacked) != currentPacked)
             {
+                _statistics?.RecordCasRetry();
                 spinWait.SpinOnce();
                 continue;
             }
+
+            RecordAllocationDecision(clockRollback, baseTimestamp, physicalTime);
 
             for (var j = 0; j < available; j++)
             {
                 destination[i + j] = CreateGuidFromState(baseTimestamp, (ushort)(startCounter + j));
             }
 
+            _statistics?.RecordGenerated(available);
             i += available;
         }
     }
@@ -213,6 +253,7 @@ public sealed class UuidV7Factory : IUuidV7Factory, IDisposable
             var (currentTimestamp, currentCounter) = UnpackState(currentPacked);
 
             var physicalTime = _timeProvider.GetUtcNow().ToUnixTimeMilliseconds();
+            var clockRollback = physicalTime < currentTimestamp;
 
             long newTimestamp;
             ushort newCounter;
@@ -229,9 +270,11 @@ public sealed class UuidV7Factory : IUuidV7Factory, IDisposable
                 if (currentCounter >= MaxCounterValue)
                 {
                     // Counter overflow
+                    _statistics?.RecordCounterOverflow();
                     switch (_effectiveOverflowBehavior)
                     {
                         case CounterOverflowBehavior.SpinWait:
+                            _statistics?.RecordSpinWait();
                             SpinWaitForNextMillisecond(physicalTime);
                             continue; // Retry with new time
 
@@ -259,6 +302,7 @@ public sealed class UuidV7Factory : IUuidV7Factory, IDisposable
                 // Time went backwards; preserve monotonicity by continuing from the current state.
                 if (currentCounter >= MaxCounterValue)
                 {
+                    _statistics?.RecordCounterOverflow();
                     newTimestamp = currentTimestamp + 1;
                     newCounter = GetRandomCounterStart();
                 }
@@ -273,11 +317,28 @@ public sealed class UuidV7Factory : IUuidV7Factory, IDisposable
 
             if (Interlocked.CompareExchange(ref _packedState, newPacked, currentPacked) == currentPacked)
             {
+                RecordAllocationDecision(clockRollback, newTimestamp, physicalTime);
                 return (newTimestamp, newCounter);
             }
 
+            _statistics?.RecordCasRetry();
             spinWait.SpinOnce();
         }
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    private void RecordAllocationDecision(bool clockRollback, long logicalTimestamp, long physicalTime)
+    {
+        var statistics = _statistics;
+        if (statistics is null)
+            return;
+
+        if (clockRollback)
+            statistics.RecordClockRollback();
+
+        var driftMs = logicalTimestamp - physicalTime;
+        if (driftMs > 0)
+            statistics.RecordLogicalTimestampAdvance(driftMs);
     }
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -362,14 +423,16 @@ public sealed class UuidV7Factory : IUuidV7Factory, IDisposable
     private sealed class RandomBuffer
     {
         private readonly RandomNumberGenerator _rng;
+        private readonly UuidV7FactoryStatistics? _statistics;
         private readonly byte[] _buffer;
         private int _position;
 
         private const int BufferSize = 256; // ~32 GUIDs worth
 
-        public RandomBuffer(RandomNumberGenerator rng)
+        public RandomBuffer(RandomNumberGenerator rng, UuidV7FactoryStatistics? statistics)
         {
             _rng = rng;
+            _statistics = statistics;
             _buffer = new byte[BufferSize];
             _position = BufferSize; // Force initial fill
         }
@@ -391,6 +454,7 @@ public sealed class UuidV7Factory : IUuidV7Factory, IDisposable
         private void Refill()
         {
             _rng.GetBytes(_buffer);
+            _statistics?.RecordRandomBufferRefill();
             _position = 0;
         }
     }

--- a/tests/Clockworks.Tests.csproj
+++ b/tests/Clockworks.Tests.csproj
@@ -6,6 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/tests/UuidV7FactoryStatisticsTests.cs
+++ b/tests/UuidV7FactoryStatisticsTests.cs
@@ -208,6 +208,22 @@ public sealed class UuidV7FactoryStatisticsTests
         Assert.Equal(1, statistics.GeneratedCount);
     }
 
+    [Fact]
+    public void AddLockFreeGuidFactory_DisposesContainerOwnedFactory()
+    {
+        var services = new ServiceCollection();
+        var time = SimulatedTimeProvider.FromUnixMs(1_700_000_000_000);
+
+        services.AddLockFreeGuidFactory(time);
+
+        var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<UuidV7Factory>();
+
+        provider.Dispose();
+
+        Assert.Throws<ObjectDisposedException>(() => factory.NewGuid());
+    }
+
     private sealed class BarrierTimeProvider(long unixMs) : TimeProvider
     {
         private DateTimeOffset _utcNow = DateTimeOffset.FromUnixTimeMilliseconds(unixMs);

--- a/tests/UuidV7FactoryStatisticsTests.cs
+++ b/tests/UuidV7FactoryStatisticsTests.cs
@@ -1,0 +1,235 @@
+using Clockworks.Abstractions;
+using Clockworks.Instrumentation;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Clockworks.Tests;
+
+public sealed class UuidV7FactoryStatisticsTests
+{
+    [Fact]
+    public void Constructor_LeavesStatisticsDisabled_WhenStatisticsAreNotSupplied()
+    {
+        using var factory = new UuidV7Factory(SimulatedTimeProvider.FromUnixMs(1_700_000_000_000), null);
+
+        Assert.Null(factory.Statistics);
+    }
+
+    [Fact]
+    public void NewGuid_RecordsGeneratedCount_WhenStatisticsAreEnabled()
+    {
+        var statistics = new UuidV7FactoryStatistics();
+        var time = SimulatedTimeProvider.FromUnixMs(1_700_000_000_000);
+        using var rng = new DeterministicRandomNumberGenerator(seed: 123);
+        using var factory = new UuidV7Factory(time, rng, CounterOverflowBehavior.SpinWait, statistics);
+
+        statistics.Reset();
+
+        _ = factory.NewGuid();
+        _ = factory.NewGuidWithTimestamp();
+        Span<Guid> batch = stackalloc Guid[7];
+        factory.NewGuids(batch);
+
+        Assert.Same(statistics, factory.Statistics);
+        Assert.Equal(9, statistics.GeneratedCount);
+        Assert.Equal(9, statistics.Snapshot().GeneratedCount);
+    }
+
+    [Fact]
+    public void NewGuid_RecordsClockRollbackAndLogicalDrift_WhenPhysicalTimeMovesBackwards()
+    {
+        const long startMs = 1_700_000_000_000;
+        var statistics = new UuidV7FactoryStatistics();
+        var time = SimulatedTimeProvider.FromUnixMs(startMs);
+        using var rng = new DeterministicRandomNumberGenerator(seed: 123);
+        using var factory = new UuidV7Factory(time, rng, CounterOverflowBehavior.SpinWait, statistics);
+
+        statistics.Reset();
+
+        _ = factory.NewGuid();
+        time.SetUnixMs(startMs - 25);
+        _ = factory.NewGuid();
+
+        var snapshot = statistics.Snapshot();
+        Assert.Equal(2, snapshot.GeneratedCount);
+        Assert.Equal(1, snapshot.ClockRollbackCount);
+        Assert.Equal(1, snapshot.LogicalTimestampAdvanceCount);
+        Assert.Equal(25, snapshot.MaxLogicalDriftMs);
+    }
+
+    [Fact]
+    public void NewGuid_RecordsCounterOverflowAndLogicalAdvance_WhenOverflowIncrementsTimestamp()
+    {
+        var statistics = new UuidV7FactoryStatistics();
+        var time = SimulatedTimeProvider.FromUnixMs(1_700_000_000_000);
+        using var rng = new DeterministicRandomNumberGenerator(seed: 1);
+        using var factory = new UuidV7Factory(
+            time,
+            rng,
+            CounterOverflowBehavior.IncrementTimestamp,
+            statistics);
+
+        statistics.Reset();
+
+        for (var i = 0; i < 5000; i++)
+            _ = factory.NewGuid();
+
+        var snapshot = statistics.Snapshot();
+        Assert.Equal(5000, snapshot.GeneratedCount);
+        Assert.True(snapshot.CounterOverflowCount >= 1);
+        Assert.True(snapshot.LogicalTimestampAdvanceCount >= 1);
+        Assert.True(snapshot.MaxLogicalDriftMs >= 1);
+    }
+
+    [Fact]
+    public void NewGuids_RecordsRandomBufferRefills_WhenBatchConsumesThreadLocalBuffer()
+    {
+        var statistics = new UuidV7FactoryStatistics();
+        var time = SimulatedTimeProvider.FromUnixMs(1_700_000_000_000);
+        using var rng = new DeterministicRandomNumberGenerator(seed: 123);
+        using var factory = new UuidV7Factory(time, rng, CounterOverflowBehavior.SpinWait, statistics);
+        var batch = new Guid[64];
+
+        statistics.Reset();
+
+        factory.NewGuids(batch);
+
+        var snapshot = statistics.Snapshot();
+        Assert.Equal(batch.Length, snapshot.GeneratedCount);
+        Assert.True(snapshot.RandomBufferRefillCount >= 1);
+    }
+
+    [Fact]
+    public async Task NewGuid_RecordsSpinWait_WhenOverflowWaitsForNextMillisecond()
+    {
+        var statistics = new UuidV7FactoryStatistics();
+        var time = SimulatedTimeProvider.FromUnixMs(1_700_000_000_000);
+        using var rng = new DeterministicRandomNumberGenerator(seed: 1);
+        using var factory = new UuidV7Factory(
+            time,
+            rng,
+            CounterOverflowBehavior.SpinWait,
+            statistics);
+
+        while (factory.NewGuid().GetCounter() != 0x0FFF)
+        {
+        }
+
+        statistics.Reset();
+
+        var pending = Task.Run(factory.NewGuid);
+
+        var observedSpin = SpinWait.SpinUntil(
+            () => statistics.CounterOverflowCount > 0 && statistics.SpinWaitCount > 0,
+            TimeSpan.FromSeconds(2));
+
+        try
+        {
+            Assert.True(observedSpin);
+
+            time.AdvanceMs(1);
+
+            await pending.WaitAsync(TimeSpan.FromSeconds(5));
+        }
+        finally
+        {
+            if (!pending.IsCompleted)
+            {
+                time.AdvanceMs(1);
+                await pending.WaitAsync(TimeSpan.FromSeconds(5));
+            }
+
+            pending.Dispose();
+        }
+
+        var snapshot = statistics.Snapshot();
+        Assert.Equal(1, snapshot.GeneratedCount);
+        Assert.Equal(1, snapshot.CounterOverflowCount);
+        Assert.Equal(1, snapshot.SpinWaitCount);
+    }
+
+    [Fact]
+    public async Task NewGuid_RecordsCasRetries_WhenConcurrentAllocationsRace()
+    {
+        const int participantCount = 8;
+        var statistics = new UuidV7FactoryStatistics();
+        var time = new BarrierTimeProvider(1_700_000_000_000);
+        using var factory = new UuidV7Factory(
+            time,
+            rng: null,
+            CounterOverflowBehavior.SpinWait,
+            statistics);
+
+        statistics.Reset();
+        time.Arm(participantCount);
+
+        var tasks = Enumerable.Range(0, participantCount)
+            .Select(_ => Task.Run(factory.NewGuid))
+            .ToArray();
+
+        await Task.WhenAll(tasks).WaitAsync(TimeSpan.FromSeconds(5));
+
+        var snapshot = statistics.Snapshot();
+        Assert.Equal(participantCount, snapshot.GeneratedCount);
+        Assert.True(snapshot.CasRetryCount >= participantCount - 1);
+        Assert.Equal(participantCount, tasks.Select(static t => t.Result).Distinct().Count());
+    }
+
+    [Fact]
+    public void Reset_ClearsAllCounters()
+    {
+        var statistics = new UuidV7FactoryStatistics();
+        var time = SimulatedTimeProvider.FromUnixMs(1_700_000_000_000);
+        using var rng = new DeterministicRandomNumberGenerator(seed: 1);
+        using var factory = new UuidV7Factory(time, rng, CounterOverflowBehavior.SpinWait, statistics);
+
+        _ = factory.NewGuid();
+        statistics.Reset();
+
+        Assert.Equal(default, statistics.Snapshot());
+    }
+
+    [Fact]
+    public void AddLockFreeGuidFactory_RegistersSharedStatistics()
+    {
+        var services = new ServiceCollection();
+        var statistics = new UuidV7FactoryStatistics();
+        var time = SimulatedTimeProvider.FromUnixMs(1_700_000_000_000);
+        using var rng = new DeterministicRandomNumberGenerator(seed: 1);
+
+        services.AddLockFreeGuidFactory(time, statistics, rng);
+
+        using var provider = services.BuildServiceProvider();
+        var factory = provider.GetRequiredService<IUuidV7Factory>();
+
+        _ = factory.NewGuid();
+
+        Assert.Same(statistics, provider.GetRequiredService<UuidV7FactoryStatistics>());
+        Assert.Equal(1, statistics.GeneratedCount);
+    }
+
+    private sealed class BarrierTimeProvider(long unixMs) : TimeProvider
+    {
+        private DateTimeOffset _utcNow = DateTimeOffset.FromUnixTimeMilliseconds(unixMs);
+        private Barrier? _barrier;
+        private int _remainingParticipants;
+
+        public void Arm(int participantCount)
+        {
+            _remainingParticipants = participantCount;
+            _barrier = new Barrier(participantCount);
+        }
+
+        public override DateTimeOffset GetUtcNow()
+        {
+            var barrier = Volatile.Read(ref _barrier);
+            if (barrier is not null && Interlocked.Decrement(ref _remainingParticipants) >= 0)
+            {
+                if (!barrier.SignalAndWait(TimeSpan.FromSeconds(5)))
+                    throw new TimeoutException("Timed out while coordinating UUIDv7 CAS contention test.");
+            }
+
+            return _utcNow;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add opt-in UuidV7FactoryStatistics snapshot counters for generation, rollback, overflow, spin-wait, logical drift, CAS retries, and random-buffer refills
- wire statistics through UuidV7Factory and DI helpers without changing the disabled hot path beyond nullable checks
- add deterministic C# coverage, F# property coverage, docs, and demo benchmark output

## Validation
- dotnet build Clockworks.sln -v minimal
- dotnet test Clockworks.sln -v minimal -m:1
- DOCS_VERSION=dev npm run docs:build (from docs/)
- dotnet run --project demo/Clockworks.Demo -- uuidv7 --bench
- dotnet pack src/Clockworks.csproj -c Release -v minimal

Benchmark sample from this machine:
- disabled: 2,376,360 ops/sec (420.8 ns/op)
- statistics enabled: 2,263,996 ops/sec (441.7 ns/op, 5.0% vs disabled)

Fixes #70