### PR TITLE
Prepare 1.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-05-16
+
 ### Fixed
 - Canonicalize explicit zero-counter `VectorClock` entries away during parse/read paths so structural equality matches vector-clock semantics for missing entries.
 
@@ -83,7 +85,8 @@ and this project aims to follow [Semantic Versioning](https://semver.org/spec/v2
 ### Build
 - Centralized common build properties in `Directory.Build.props`.
 
-[Unreleased]: https://github.com/dexcompiler/Clockworks/compare/v1.3.1...HEAD
+[Unreleased]: https://github.com/dexcompiler/Clockworks/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/dexcompiler/Clockworks/compare/v1.3.1...v1.4.0
 [1.3.1]: https://github.com/dexcompiler/Clockworks/releases/tag/v1.3.1
 [1.3.0]: https://github.com/dexcompiler/Clockworks/releases/tag/v1.3.0
 [1.2.0]: https://github.com/dexcompiler/Clockworks/releases/tag/v1.2.0

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,8 @@ This page mirrors the repository root `CHANGELOG.md`.
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-05-16
+
 ### Fixed
 - Canonicalize explicit zero-counter `VectorClock` entries away during parse/read paths so structural equality matches vector-clock semantics for missing entries.
 

--- a/src/Clockworks.csproj
+++ b/src/Clockworks.csproj
@@ -13,7 +13,7 @@
     <PackageId>Clockworks</PackageId>
     <AssemblyName>Clockworks</AssemblyName>
     <RootNamespace>Clockworks</RootNamespace>
-    <Version>1.3.2</Version>
+    <Version>1.4.0</Version>
     <Authors>Dexter Ajoku</Authors>
     <Company>CloudyBox</Company>
     <Description>Clockworks is a .NET library for deterministic, fully controllable time in distributed-system simulations and tests. It provides a simulated TimeProvider with deterministic timer scheduling, TimeProvider-driven timeouts, UUIDv7 generation, and Hybrid Logical Clock (HLC) utilities with lightweight instrumentation.</Description>


### PR DESCRIPTION
## Summary
- bump Clockworks package version to 1.4.0
- move accumulated changelog entries into a dated 1.4.0 section
- update changelog compare links for the next Unreleased range

## Validation
- DOTNET_CLI_HOME=/tmp/clockworks-dotnet NUGET_HTTP_CACHE_PATH=/tmp/clockworks-nuget-http NUGET_PACKAGES=/tmp/clockworks-nuget-packages dotnet test Clockworks.sln -v minimal -m:1
- npm run docs:build
- DOTNET_CLI_HOME=/tmp/clockworks-dotnet NUGET_HTTP_CACHE_PATH=/tmp/clockworks-nuget-http NUGET_PACKAGES=/tmp/clockworks-nuget-packages dotnet pack src/Clockworks.csproj -c Release -v minimal

## Release note
Pack validation produced src/bin/Release/Clockworks.1.4.0.nupkg locally.